### PR TITLE
Add size()/empty() to Contacts

### DIFF
--- a/include/session/config/contacts.h
+++ b/include/session/config/contacts.h
@@ -67,7 +67,7 @@ bool contacts_get(const config_object* conf, contacts_contact* contact, const ch
 ///
 /// This is the method that should usually be used to create or update a contact, followed by
 /// setting fields in the contact, and then giving it to contacts_set().
-bool contacts_get_or_create(
+bool contacts_get_or_construct(
         const config_object* conf, contacts_contact* contact, const char* session_id)
         __attribute__((warn_unused_result));
 
@@ -79,7 +79,7 @@ void contacts_set(config_object* conf, const contacts_contact* contact);
 // is simple enough; for example to update `approved` and leave everything else unchanged:
 //
 // contacts_contact c;
-// if (contacts_get_or_create(conf, &c, some_session_id)) {
+// if (contacts_get_or_construct(conf, &c, some_session_id)) {
 //     const char* new_nickname = "Joe";
 //     c.approved = new_nickname;
 //     contacts_set_or_create(conf, &c);

--- a/include/session/config/contacts.h
+++ b/include/session/config/contacts.h
@@ -92,6 +92,9 @@ void contacts_set(config_object* conf, const contacts_contact* contact);
 /// iteration; see details below.
 bool contacts_erase(config_object* conf, const char* session_id);
 
+/// Returns the number of contacts.
+size_t contacts_size(const config_object* conf);
+
 /// Functions for iterating through the entire contact list, in sorted order.  Intended use is:
 ///
 ///     contacts_contact c;

--- a/include/session/config/contacts.hpp
+++ b/include/session/config/contacts.hpp
@@ -84,16 +84,17 @@ class Contacts : public ConfigBase {
 
     /// Similar to get(), but if the session ID does not exist this returns a filled-out
     /// contact_info containing the session_id (all other fields will be empty/defaulted).  This is
-    /// intended to be combined with `set` to set-or-create a record.  Note that this does not add
-    /// the session id to the contact list when called: that requires also calling `set` with this
-    /// value.
-    contact_info get_or_create(std::string_view pubkey_hex) const;
+    /// intended to be combined with `set` to set-or-create a record.
+    ///
+    /// NB: calling this does *not* add the session id to the contact list when called: that
+    /// requires also calling `set` with this value.
+    contact_info get_or_construct(std::string_view pubkey_hex) const;
 
     /// Sets or updates multiple contact info values at once with the given info.  The usual use is
     /// to access the current info, change anything desired, then pass it back into set_contact,
     /// e.g.:
     ///
-    ///     auto c = contacts.get_or_create(pubkey);
+    ///     auto c = contacts.get_or_construct(pubkey);
     ///     c.name = "Session User 42";
     ///     c.nickname = "BFF";
     ///     contacts.set(c);

--- a/include/session/config/contacts.hpp
+++ b/include/session/config/contacts.hpp
@@ -119,6 +119,12 @@ class Contacts : public ConfigBase {
     /// example.
     iterator erase(iterator it);
 
+    /// Returns the number of contacts.
+    size_t size() const;
+
+    /// Returns true if the contact list is empty.
+    bool empty() const { return size() == 0; }
+
     /// Iterators for iterating through all contacts.  Typically you access this implicit via a for
     /// loop over the `Contacts` object:
     ///

--- a/src/config/contacts.cpp
+++ b/src/config/contacts.cpp
@@ -284,6 +284,16 @@ Contacts::iterator Contacts::erase(iterator it) {
     return it;
 }
 
+size_t Contacts::size() const {
+    if (auto* c = data["c"].dict())
+        return c->size();
+    return 0;
+}
+
+LIBSESSION_C_API size_t contacts_size(const config_object* conf) {
+    return unbox<Contacts>(conf)->size();
+}
+
 /// Load _val from the current iterator position; if it is invalid, skip to the next key until we
 /// find one that is valid (or hit the end).
 void Contacts::iterator::_load_info() {

--- a/src/config/contacts.cpp
+++ b/src/config/contacts.cpp
@@ -166,17 +166,17 @@ LIBSESSION_C_API bool contacts_get(
     return false;
 }
 
-contact_info Contacts::get_or_create(std::string_view pubkey_hex) const {
+contact_info Contacts::get_or_construct(std::string_view pubkey_hex) const {
     if (auto maybe = get(pubkey_hex))
         return *std::move(maybe);
 
     return contact_info{std::string{pubkey_hex}};
 }
 
-LIBSESSION_C_API bool contacts_get_or_create(
+LIBSESSION_C_API bool contacts_get_or_construct(
         const config_object* conf, contacts_contact* contact, const char* session_id) {
     try {
-        unbox<Contacts>(conf)->get_or_create(session_id).into(*contact);
+        unbox<Contacts>(conf)->get_or_construct(session_id).into(*contact);
         return true;
     } catch (...) {
         return false;
@@ -231,32 +231,32 @@ LIBSESSION_C_API void contacts_set(config_object* conf, const contacts_contact* 
 }
 
 void Contacts::set_name(std::string_view session_id, std::string_view name) {
-    auto c = get_or_create(session_id);
+    auto c = get_or_construct(session_id);
     c.name = name;
     set(c);
 }
 void Contacts::set_nickname(std::string_view session_id, std::string_view nickname) {
-    auto c = get_or_create(session_id);
+    auto c = get_or_construct(session_id);
     c.nickname = nickname;
     set(c);
 }
 void Contacts::set_profile_pic(std::string_view session_id, profile_pic pic) {
-    auto c = get_or_create(session_id);
+    auto c = get_or_construct(session_id);
     c.profile_picture = std::move(pic);
     set(c);
 }
 void Contacts::set_approved(std::string_view session_id, bool approved) {
-    auto c = get_or_create(session_id);
+    auto c = get_or_construct(session_id);
     c.approved = approved;
     set(c);
 }
 void Contacts::set_approved_me(std::string_view session_id, bool approved_me) {
-    auto c = get_or_create(session_id);
+    auto c = get_or_construct(session_id);
     c.approved_me = approved_me;
     set(c);
 }
 void Contacts::set_blocked(std::string_view session_id, bool blocked) {
-    auto c = get_or_create(session_id);
+    auto c = get_or_construct(session_id);
     c.blocked = blocked;
     set(c);
 }

--- a/tests/test_config_contacts.cpp
+++ b/tests/test_config_contacts.cpp
@@ -35,6 +35,9 @@ TEST_CASE("Contacts", "[config][contacts]") {
 
     CHECK_FALSE(contacts.get(definitely_real_id));
 
+    CHECK(contacts.empty());
+    CHECK(contacts.size() == 0);
+
     auto c = contacts.get_or_create(definitely_real_id);
 
     CHECK_FALSE(c.name);
@@ -118,12 +121,15 @@ TEST_CASE("Contacts", "[config][contacts]") {
     // Iterate through and make sure we got everything we expected
     std::vector<std::string> session_ids;
     std::vector<std::string> nicknames;
+    CHECK(contacts.size() == 2);
+    CHECK_FALSE(contacts.empty());
     for (const auto& cc : contacts) {
         session_ids.push_back(cc.session_id);
         nicknames.emplace_back(cc.nickname.value_or("(N/A)"));
     }
 
     REQUIRE(session_ids.size() == 2);
+    REQUIRE(session_ids.size() == contacts.size());
     CHECK(session_ids[0] == definitely_real_id);
     CHECK(session_ids[1] == another_id);
     CHECK(nicknames[0] == "Joey");
@@ -299,6 +305,7 @@ TEST_CASE("Contacts (C API)", "[config][contacts][c]") {
     std::vector<std::string> session_ids;
     std::vector<std::string> nicknames;
 
+    CHECK(contacts_size(conf) == 2);
     contacts_iterator* it = contacts_iterator_new(conf);
     contacts_contact ci;
     for (; !contacts_iterator_done(it, &ci); contacts_iterator_advance(it)) {

--- a/tests/test_config_contacts.cpp
+++ b/tests/test_config_contacts.cpp
@@ -270,7 +270,7 @@ TEST_CASE("Contacts (C API)", "[config][contacts][c]") {
     free(to_push);
 
     contacts_contact c3;
-    REQUIRE(contacts_get(conf, &c3, definitely_real_id));
+    REQUIRE(contacts_get(conf2, &c3, definitely_real_id));
     CHECK(c3.name == "Joe"sv);
     CHECK(c3.nickname == "Joey"sv);
     CHECK(c3.approved);

--- a/tests/test_config_contacts.cpp
+++ b/tests/test_config_contacts.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Contacts", "[config][contacts]") {
     CHECK(contacts.empty());
     CHECK(contacts.size() == 0);
 
-    auto c = contacts.get_or_create(definitely_real_id);
+    auto c = contacts.get_or_construct(definitely_real_id);
 
     CHECK_FALSE(c.name);
     CHECK_FALSE(c.nickname);
@@ -100,7 +100,7 @@ TEST_CASE("Contacts", "[config][contacts]") {
     CHECK_FALSE(x->blocked);
 
     auto another_id = "051111111111111111111111111111111111111111111111111111111111111111"sv;
-    auto c2 = contacts2.get_or_create(another_id);
+    auto c2 = contacts2.get_or_construct(another_id);
     // We're not setting any fields, but we should still keep a record of the session id
     contacts2.set(c2);
 
@@ -218,7 +218,7 @@ TEST_CASE("Contacts (C API)", "[config][contacts][c]") {
     contacts_contact c;
     CHECK_FALSE(contacts_get(conf, &c, definitely_real_id));
 
-    CHECK(contacts_get_or_create(conf, &c, definitely_real_id));
+    CHECK(contacts_get_or_construct(conf, &c, definitely_real_id));
 
     CHECK(c.session_id == std::string_view{definitely_real_id});
     CHECK(c.name == nullptr);
@@ -280,7 +280,7 @@ TEST_CASE("Contacts (C API)", "[config][contacts][c]") {
     CHECK(c3.profile_pic.url == nullptr);
 
     auto another_id = "051111111111111111111111111111111111111111111111111111111111111111";
-    REQUIRE(contacts_get_or_create(conf, &c3, another_id));
+    REQUIRE(contacts_get_or_construct(conf, &c3, another_id));
     CHECK(c3.name == nullptr);
     CHECK(c3.nickname == nullptr);
     CHECK_FALSE(c3.approved);


### PR DESCRIPTION
- Adds `.size()` and `.empty()` to Contacts for easier querying.
- Rename `get_or_create` to `get_or_construct` because this only constructs a contact object, but doesn't actually "create" it in the config until you `set()` it.
- Fix minor bug in test code