### PR TITLE
Add optional ownership of string view

### DIFF
--- a/include/session/config/contacts.hpp
+++ b/include/session/config/contacts.hpp
@@ -49,8 +49,19 @@ struct contact_info {
     contact_info(const struct contacts_contact& c);  // From c struct
     void into(contacts_contact& c);                  // Into c struct
 
+    // Sets a name, storing the name internally in the object.  This is intended for use where the
+    // source string is a temporary may not outlive the `contact_info` object: the name is first
+    // copied into an internal std::string, and then the name string_view references that.
+    void set_name(std::string name);
+
+    // Same as above, but for nickname.
+    void set_nickname(std::string nickname);
+
   private:
     friend class Contacts;
+
+    std::string name_;
+    std::string nickname_;
 
     void load(const dict& info_dict);
 };
@@ -101,8 +112,8 @@ class Contacts : public ConfigBase {
     void set(const contact_info& contact);
 
     /// Alternative to `set()` for setting individual fields.
-    void set_name(std::string_view session_id, std::string_view name);
-    void set_nickname(std::string_view session_id, std::string_view nickname);
+    void set_name(std::string_view session_id, std::string name);
+    void set_nickname(std::string_view session_id, std::string nickname);
     void set_profile_pic(std::string_view session_id, profile_pic pic);
     void set_approved(std::string_view session_id, bool approved);
     void set_approved_me(std::string_view session_id, bool approved_me);

--- a/include/session/config/profile_pic.hpp
+++ b/include/session/config/profile_pic.hpp
@@ -3,24 +3,37 @@
 #include "session/types.hpp"
 
 namespace session::config {
+
 // Profile pic info.  Note that `url` is null terminated (though the null lies just beyond the end
 // of the string view: that is, it views into a full std::string).
 struct profile_pic {
+  private:
+    std::string url_;
+    ustring key_;
+
+  public:
     std::string_view url;
     ustring_view key;
 
+    // Default constructor, makes an empty profile pic
+    profile_pic() = default;
+
+    // Constructs from string views: the values must stay alive for the duration of the profile_pic
+    // instance.  (If not, use `set_url`/`set_key` or the rvalue-argument constructor instead).
     profile_pic(std::string_view url, ustring_view key) : url{url}, key{key} {}
+
+    // Constructs from temporary strings; the strings are stored/managed internally
+    profile_pic(std::string&& url, ustring&& key) :
+            url_{std::move(url)}, key_{std::move(key)}, url{url_}, key{key_} {}
 
     // Returns true if either url or key are empty
     bool empty() const { return url.empty() || key.empty(); }
 
-    // Guard against accidentally passing in a temporary string or ustring:
-    template <
-            typename UrlType,
-            typename KeyType,
-            std::enable_if_t<
-                    std::is_same_v<UrlType, std::string> || std::is_same_v<KeyType, ustring>>>
-    profile_pic(UrlType&& url, KeyType&& key) = delete;
+    // Sets the url or key to a temporary value that needs to be copied and owned by this
+    // profile_pic object.  (This is only needed when the source string may not outlive the
+    // profile_pic object; if it does, the `url` or `key` can be assigned to directly).
+    void set_url(std::string url);
+    void set_key(ustring key);
 };
 
 }  // namespace session::config

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(config
     config/contacts.cpp
     config/encrypt.cpp
     config/error.c
+    config/profile_pic.cpp
     config/user_profile.cpp
     fields.cpp
 )

--- a/src/config/contacts.cpp
+++ b/src/config/contacts.cpp
@@ -39,6 +39,16 @@ contact_info::contact_info(std::string sid) : session_id{std::move(sid)} {
     check_session_id(session_id);
 }
 
+void contact_info::set_name(std::string n) {
+    name_ = std::move(n);
+    name = name_;
+}
+
+void contact_info::set_nickname(std::string n) {
+    nickname_ = std::move(n);
+    nickname = nickname_;
+}
+
 Contacts::Contacts(ustring_view ed25519_secretkey, std::optional<ustring_view> dumped) :
         ConfigBase{dumped} {
     load_key(ed25519_secretkey);
@@ -136,7 +146,7 @@ contact_info::contact_info(const contacts_contact& c) : session_id{c.session_id,
     if (c.profile_pic.url && std::strlen(c.profile_pic.url) && c.profile_pic.key &&
         c.profile_pic.keylen > 0)
         profile_picture.emplace(
-                c.profile_pic.url, ustring_view{c.profile_pic.key, c.profile_pic.keylen});
+                c.profile_pic.url, ustring{c.profile_pic.key, c.profile_pic.keylen});
     approved = c.approved;
     approved_me = c.approved_me;
     blocked = c.blocked;
@@ -230,14 +240,14 @@ LIBSESSION_C_API void contacts_set(config_object* conf, const contacts_contact* 
     unbox<Contacts>(conf)->set(contact_info{*contact});
 }
 
-void Contacts::set_name(std::string_view session_id, std::string_view name) {
+void Contacts::set_name(std::string_view session_id, std::string name) {
     auto c = get_or_construct(session_id);
-    c.name = name;
+    c.set_name(std::move(name));
     set(c);
 }
-void Contacts::set_nickname(std::string_view session_id, std::string_view nickname) {
+void Contacts::set_nickname(std::string_view session_id, std::string nickname) {
     auto c = get_or_construct(session_id);
-    c.nickname = nickname;
+    c.set_nickname(std::move(nickname));
     set(c);
 }
 void Contacts::set_profile_pic(std::string_view session_id, profile_pic pic) {

--- a/src/config/profile_pic.cpp
+++ b/src/config/profile_pic.cpp
@@ -1,0 +1,13 @@
+#include "session/config/profile_pic.hpp"
+
+namespace session::config {
+
+void profile_pic::set_url(std::string new_url) {
+    url = (url_ = std::move(new_url));
+}
+
+void profile_pic::set_key(ustring new_key) {
+    key = (key_ = std::move(new_key));
+}
+
+}  // namespace session::config


### PR DESCRIPTION
Getting a string *into* storage can be a little cumbersome currently because the structs have string_views, but that means the caller has to worry about keeping their string_view referenced data alive.

This fixes it by adding `set_name()` and similar methods for name/nickname/profile url/profile key to allow callers to have the struct manage the underlying string ownership.