### PR TITLE
Add automatic compression/decompression

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "external/ios-cmake"]
 	path = external/ios-cmake
 	url = https://github.com/leetal/ios-cmake
+[submodule "external/zstd"]
+	path = external/zstd
+	url = https://github.com/facebook/zstd.git

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -123,3 +123,11 @@ target_include_directories(libsodium-internal
     SYSTEM BEFORE
     INTERFACE
     ${CMAKE_CURRENT_BINARY_DIR}/libsodium-internal/include)
+
+set(ZSTD_BUILD_PROGRAMS OFF CACHE BOOL "")
+set(ZSTD_BUILD_TESTS OFF CACHE BOOL "")
+set(ZSTD_BUILD_CONTRIB OFF CACHE BOOL "")
+set(ZSTD_BUILD_SHARED OFF CACHE BOOL "")
+set(ZSTD_BUILD_STATIC ON CACHE BOOL "")
+set(ZSTD_MULTITHREAD_SUPPORT OFF CACHE BOOL "")
+add_subdirectory(zstd/build/cmake)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -131,3 +131,14 @@ set(ZSTD_BUILD_SHARED OFF CACHE BOOL "")
 set(ZSTD_BUILD_STATIC ON CACHE BOOL "")
 set(ZSTD_MULTITHREAD_SUPPORT OFF CACHE BOOL "")
 add_subdirectory(zstd/build/cmake)
+# zstd's cmake doesn't properly set up include paths on its targets, so we have to wrap it in an
+# interface target that does:
+add_library(libzstd_static_fixed_includes INTERFACE)
+target_include_directories(libzstd_static_fixed_includes INTERFACE zstd/lib zstd/lib/common)
+target_link_libraries(libzstd_static_fixed_includes INTERFACE libzstd_static)
+add_library(libzstd::static ALIAS libzstd_static_fixed_includes)
+export(
+    TARGETS libzstd_static_fixed_includes
+    NAMESPACE libsession::
+    FILE libsessionZstd.cmake
+)

--- a/include/session/config/base.hpp
+++ b/include/session/config/base.hpp
@@ -416,6 +416,11 @@ class ConfigBase {
     /// to use.  This is rarely needed externally; it is public merely for testing purposes.
     virtual const char* encryption_domain() const = 0;
 
+    /// The zstd compression level to use for this type.  Subclasses can override this if they have
+    /// some particular special compression level, or to disable compression entirely (by returning
+    /// std::nullopt).  The default is zstd level 1.
+    virtual std::optional<int> compression_level() const { return 1; }
+
     // How many config lags should be used for this object; default to 5.  Implementing subclasses
     // can override to return a different constant if desired.  More lags require more "diff"
     // storage in the config messages, but also allow for a higher tolerance of simultaneous message

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,7 @@ target_link_libraries(config
     PUBLIC
     crypto
     oxenc::oxenc
+    libzstd_static
     common)
 
 add_library(libsession::config ALIAS config)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,7 +36,7 @@ target_link_libraries(config
     PUBLIC
     crypto
     oxenc::oxenc
-    libzstd_static
+    libzstd::static
     common)
 
 add_library(libsession::config ALIAS config)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ add_subdirectory(Catch2)
 
 add_executable(testAll
     test_bt_merge.cpp
+    test_compression.cpp
     test_config_userprofile.cpp
     test_configdata.cpp
     test_config_contacts.cpp

--- a/tests/test_compression.cpp
+++ b/tests/test_compression.cpp
@@ -1,0 +1,136 @@
+
+#include <oxenc/hex.h>
+#include <session/config/encrypt.h>
+#include <session/config/user_profile.h>
+#include <sodium/crypto_sign_ed25519.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <string_view>
+
+#include "utils.hpp"
+
+namespace session::config {
+void compress_message(ustring& msg, int level);
+}
+
+using namespace std::literals;
+using namespace oxenc::literals;
+
+TEST_CASE("compression", "[config][compression]") {
+
+    auto data =
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hexbytes;
+
+    CHECK(data.size() == 81);
+
+    auto d = data;
+    session::config::compress_message(d, 1);
+
+    CHECK(d[0] == 'z');
+    CHECK(d.size() == 18);
+    CHECK(to_hex(d) == "7a28b52ffd205145000010aaaa01008c022c");
+
+    d = data;
+    session::config::compress_message(d, 5);
+    CHECK(d[0] == 'z');
+    CHECK(d.size() == 17);
+    CHECK(to_hex(d) == "7a28b52ffd20513d000008aa01000dea84");
+
+    // This message (from the user profile test case) doesn't compress any better than plaintext
+    // with zstd compression, so the compress_message call shouldn't change it.
+    // clang-format off
+    data =
+        "d"
+          "1:#" "i1e"
+          "1:&" "d"
+            "1:n" "6:Kallie"
+            "1:p" "34:http://example.org/omg-pic-123.bmp"
+            "1:q" "6:secret"
+          "e"
+          "1:<" "l"
+            "l"
+              "i0e"
+              "32:"_bytes +
+                "ea173b57beca8af18c3519a7bbf69c3e7a05d1c049fa9558341d8ebb48b0c965"_hexbytes +
+              "de"
+            "e"
+          "e"
+          "1:=" "d"
+            "1:n" "0:"
+            "1:p" "0:"
+            "1:q" "0:"
+          "e"
+        "e"_bytes;
+    //
+    // If we add some more repetition in it, though, it will:
+    auto data2 =
+        "d"
+          "1:#" "i1e"
+          "1:&" "d"
+            "1:n" "12:KallieKallie"
+            "1:p" "29:http://kallie.example.org/Kallie.bmp"
+            "1:q" "24:KallieKalliesecretKallie"
+          "e"
+          "1:<" "l"
+            "l"
+              "i0e"
+              "32:"_bytes +
+                "ea173b57beca8af18c3519a7bbf69c3e7a05d1c049fa9558341d8ebb48b0c965"_hexbytes +
+              "de"
+            "e"
+          "e"
+          "1:=" "d"
+            "1:n" "0:"
+            "1:p" "0:"
+            "1:q" "0:"
+          "e"
+        "e"_bytes;
+    // clang-format on
+
+    d = data;
+    intptr_t dptr = reinterpret_cast<intptr_t>(d.data());
+
+    // Doesn't compress, so shouldn't change:
+    CHECK(d.size() == 142);
+    session::config::compress_message(d, 1);
+    CHECK(d[0] == 'd');
+    CHECK(d.size() == 142);
+    CHECK(reinterpret_cast<intptr_t>(d.data()) == dptr);
+
+    // Test some compression levels with exact compression values.  (Note that this will change if
+    // we change the version of external/zstd, but should be constant otherwise for any given
+    // version of zstd).
+    d = data2;
+    session::config::compress_message(d, 1);
+    CHECK(d[0] == 'z');
+    CHECK(d.size() == 161);
+    CHECK(d.size() < data2.size());
+    CHECK(to_hex(d) ==
+          "7a28b52ffd20aabd0400640864313a23693165313a2664313a6e31323a4b616c6c6965313a7032393a68"
+          "7474703a2f2f6b2e6578616d706c652e6f72672f4b626d70313a71323473656372657465313a3c6c6c69"
+          "306533323aea173b57beca8af18c3519a7bbf69c3e7a05d1c049fa9558341d8ebb48b0c9656465656531"
+          "3a3d64313a6e303a313a70303a313a71303a656505003587f2d5e1c02836af9aa13401");
+
+    d = data2;
+    session::config::compress_message(d, 5);
+    CHECK(d[0] == 'z');
+    CHECK(d.size() == 156);
+    CHECK(d.size() < data2.size());
+    CHECK(to_hex(d) ==
+          "7a28b52ffd20aa950400a40764313a23693165313a2664313a6e31323a4b616c6c6965313a7032393a68"
+          "7474703a2f2f6b2e6578616d706c652e6f72672f4b626d70313a71323473656372657465313a3c6c6c69"
+          "306533323aea173b57beca8af18c3519a7bbf69c3e7a05d1c049fa9558341d8ebb48b0c96564653d303a"
+          "313a7071303a65650800a8d0880966a9827e19e0572706a3d8bc6a86d204");
+
+    d = data2;
+    session::config::compress_message(d, 19);
+    CHECK(d[0] == 'z');
+    CHECK(d.size() == 157);  // Yeah, it actually gets *bigger* with supposedly "higher" compression
+    CHECK(d.size() < data2.size());
+    CHECK(to_hex(d) ==
+          "7a28b52ffd20aa9d0400e40764313a23693165313a2664313a6e31323a4b616c6c6965313a7032393a68"
+          "7474703a2f2f6b2e6578616d706c652e6f72672f4b626d70313a71323473656372657465313a3c6c6c69"
+          "306533323aea173b57beca8af18c3519a7bbf69c3e7a05d1c049fa9558341d8ebb48b0c96564653d6431"
+          "3a6e303a313a7071303a6565070028812c55282f03fceac460149b57cd509a");
+}


### PR DESCRIPTION
We use an embedded static version of zstd for compression, which gives us identical compression results for the same input (at least as long as we keep the same zstd version).

We always *try* to compress, but only actually use the compressed version if it ends up smaller (for very small messages, in particular, there often isn't enough repeated content to overcome the small overhead of compression).