### PR TITLE
Obsolete hash tracking

### DIFF
--- a/include/session/config/base.h
+++ b/include/session/config/base.h
@@ -118,8 +118,8 @@ bool config_needs_dump(const config_object* conf);
 /// Struct containing a list of C strings.  Typically where this is returned by this API it must be
 /// freed (via `free()`) when done with it.
 typedef struct config_string_list {
-    char** value; // array of null-terminated C strings
-    size_t len; // length of `value`
+    char** value;  // array of null-terminated C strings
+    size_t len;    // length of `value`
 } config_string_list;
 
 /// Obtains the current active hashes.  Note that this will be empty if the current hash is unknown

--- a/include/session/config/base.h
+++ b/include/session/config/base.h
@@ -55,31 +55,50 @@ int16_t config_storage_namespace(const config_object* conf);
 /// config object may be unchanged, complete replaced, or updated and needing a push, depending on
 /// the messages that are merged; the caller should check config_needs_push().
 ///
-/// `configs` is an array of pointers to the start of the strings; `lengths` is an array of string
-/// lengths; `count` is the length of those two arrays.
+/// `msg_hashes` is an array of null-terminated C strings containing the hashes of the configs being
+/// provided.
+/// `configs` is an array of pointers to the start of the (binary) data.
+/// `lengths` is an array of lengths of the binary data
+/// `count` is the length of all three arrays.
 int config_merge(
-        config_object* conf, const unsigned char** configs, const size_t* lengths, size_t count);
+        config_object* conf,
+        const char** msg_hashes,
+        const unsigned char** configs,
+        const size_t* lengths,
+        size_t count);
 
 /// Returns true if this config object contains updated data that has not yet been confirmed stored
 /// on the server.
 bool config_needs_push(const config_object* conf);
 
-/// Obtains the configuration data that needs to be pushed to the server.  A new buffer of the
-/// appropriate size is malloc'd and set to `out` The output is written to a new malloc'ed buffer of
-/// the appropriate size; the buffer and the output length are set in the `out` and `outlen`
-/// parameters.  Note that this is binary data, *not* a null-terminated C string.
+/// Returned struct of config push data.
+typedef struct config_push_data {
+    // The config seqno (to be provided later in `config_confirm_pushed`).
+    seqno_t seqno;
+    // The config message to push (binary data, not null-terminated).
+    unsigned char* config;
+    // The length of `config`
+    size_t config_len;
+    // Array of obsolete message hashes to delete; each element is a null-terminated C string
+    char** obsolete;
+    // length of `obsolete`
+    size_t obsolete_len;
+} config_push_data;
+
+/// Obtains the configuration data that needs to be pushed to the server.
 ///
 /// Generally this call should be guarded by a call to `config_needs_push`, however it can be used
 /// to re-obtain the current serialized config even if no push is needed (for example, if the client
 /// wants to re-submit it after a network error).
 ///
-/// NB: The returned buffer belongs to the caller: that is, the caller *MUST* free() it when done
-/// with it.
-seqno_t config_push(config_object* conf, unsigned char** out, size_t* outlen);
+/// NB: The returned pointer belongs to the caller: that is, the caller *MUST* free() it when
+/// done with it.
+config_push_data* config_push(config_object* conf);
 
-/// Reports that data obtained from `config_push` has been successfully stored on the server.  The
-/// seqno value is the one returned by the config_push call that yielded the config data.
-void config_confirm_pushed(config_object* conf, seqno_t seqno);
+/// Reports that data obtained from `config_push` has been successfully stored on the server with
+/// message hash `msg_hash`.  The seqno value is the one returned by the config_push call that
+/// yielded the config data.
+void config_confirm_pushed(config_object* conf, seqno_t seqno, const char* msg_hash);
 
 /// Returns a binary dump of the current state of the config object.  This dump can be used to
 /// resurrect the object at a later point (e.g. after a restart).  Allocates a new buffer and sets

--- a/include/session/config/base.h
+++ b/include/session/config/base.h
@@ -115,6 +115,20 @@ void config_dump(config_object* conf, unsigned char** out, size_t* outlen);
 /// and saving the `config_dump()` data again.
 bool config_needs_dump(const config_object* conf);
 
+/// Struct containing a list of C strings.  Typically where this is returned by this API it must be
+/// freed (via `free()`) when done with it.
+typedef struct config_string_list {
+    char** value; // array of null-terminated C strings
+    size_t len; // length of `value`
+} config_string_list;
+
+/// Obtains the current active hashes.  Note that this will be empty if the current hash is unknown
+/// or not yet determined (for example, because the current state is dirty or because the most
+/// recent push is still pending and we don't know the hash yet).
+///
+/// The returned pointer belongs to the caller and must be freed via `free()` when done with it.
+config_string_list* config_current_hashes(const config_object* conf);
+
 /// Config key management; see the corresponding method docs in base.hpp.  All `key` arguments here
 /// are 32-byte binary buffers (and since fixed-length, there is no keylen argument).
 void config_add_key(config_object* conf, const unsigned char* key);

--- a/include/session/config/base.hpp
+++ b/include/session/config/base.hpp
@@ -465,20 +465,10 @@ class ConfigBase {
     // Will throw on serious error (i.e. if neither the current nor any of the given configs are
     // parseable).  This should not happen (the current config, at least, should always be
     // re-parseable).
-    //
-    // Immediately after calling this you can get `obsolete_messages()` to obtain message hashes
-    // that are now stale and can be deleted from the server.  (The returned list may include the
-    // provided hashes, or the hash of the message prior to the merge).  Any configs that could not
-    // be properly consumed will *not* be included in the obsolete message list as we assume they
-    // are from the future and so we should leave them alone.
     virtual int merge(const std::vector<std::pair<std::string, ustring_view>>& configs);
 
     // Same as above but takes the values as ustring's as sometimes that is more convenient.
     int merge(const std::vector<std::pair<std::string, ustring>>& configs);
-
-    // Call this to report that the given message hash has been deleted from the server; this
-    // removes the hash from the list returned by `obsolete_messages()`.
-    void confirm_removed(const std::string& msg_hash);
 
     // Returns true if we are currently dirty (i.e. have made changes that haven't been serialized
     // yet).

--- a/include/session/config/base.hpp
+++ b/include/session/config/base.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <session/config.hpp>
 #include <type_traits>
+#include <unordered_set>
 #include <variant>
 #include <vector>
 
@@ -64,6 +65,15 @@ class ConfigBase {
     size_t _keys_size = 0;
     size_t _keys_capacity = 0;
 
+    // Contains the current active message hash, as fed into us in `confirm_pushed()`.  Empty if we
+    // don't know it yet.  When we dirty the config this value gets moved into `old_hashes_` to be
+    // removed by the next push.
+    std::string _curr_hash;
+
+    // Contains obsolete known message hashes that are obsoleted by the most recent merge or push;
+    // these are returned (and cleared) when `push` is called.
+    std::unordered_set<std::string> _old_hashes;
+
   protected:
     // Constructs a base config by loading the data from a dump as produced by `dump()`.  If the
     // dump is nullopt then an empty base config is constructed with no config settings and seqno
@@ -74,11 +84,10 @@ class ConfigBase {
     // calling set_state, which sets to to true implicitly).
     bool _needs_dump = false;
 
-    // Sets the current state; this also sets _needs_dump to true.
-    void set_state(ConfigState s) {
-        _state = s;
-        _needs_dump = true;
-    }
+    // Sets the current state; this also sets _needs_dump to true.  If transitioning to a dirty
+    // state and we know our current message hash, that hash gets added to `old_hashes_` to be
+    // deleted at the next push.
+    void set_state(ConfigState s);
 
     // Invokes the `logger` callback if set, does nothing if there is no logger.
     void log(LogLevel lvl, std::string msg) {
@@ -445,18 +454,31 @@ class ConfigBase {
     // This takes all of the messages pulled down from the server and does whatever is necessary to
     // merge (or replace) the current values.
     //
+    // Values are pairs of the message hash (as provided by the server) and the raw message body.
+    //
     // After this call the caller should check `needs_push()` to see if the data on hand was updated
-    // and needs to be pushed to the server again.
+    // and needs to be pushed to the server again (for example, because the data contained conflicts
+    // that required another update to resolve).
     //
     // Returns the number of the given config messages that were successfully parsed.
     //
     // Will throw on serious error (i.e. if neither the current nor any of the given configs are
     // parseable).  This should not happen (the current config, at least, should always be
     // re-parseable).
-    virtual int merge(const std::vector<ustring_view>& configs);
+    //
+    // Immediately after calling this you can get `obsolete_messages()` to obtain message hashes
+    // that are now stale and can be deleted from the server.  (The returned list may include the
+    // provided hashes, or the hash of the message prior to the merge).  Any configs that could not
+    // be properly consumed will *not* be included in the obsolete message list as we assume they
+    // are from the future and so we should leave them alone.
+    virtual int merge(const std::vector<std::pair<std::string, ustring_view>>& configs);
 
-    // Same as above but takes a vector of ustring's as sometimes that is more convenient.
-    int merge(const std::vector<ustring>& configs);
+    // Same as above but takes the values as ustring's as sometimes that is more convenient.
+    int merge(const std::vector<std::pair<std::string, ustring>>& configs);
+
+    // Call this to report that the given message hash has been deleted from the server; this
+    // removes the hash from the list returned by `obsolete_messages()`.
+    void confirm_removed(const std::string& msg_hash);
 
     // Returns true if we are currently dirty (i.e. have made changes that haven't been serialized
     // yet).
@@ -466,31 +488,51 @@ class ConfigBase {
     // unmodified).
     bool is_clean() const { return _state == ConfigState::Clean; }
 
+    // The current config hash; this will be empty if the current hash is unknown or the current
+    // state is not clean.
+    const std::string& current_hash() const { return _curr_hash; }
+
     // Returns true if this object contains updated data that has not yet been confirmed stored on
     // the server.  This will be true whenever `is_clean()` is false: that is, if we are currently
     // "dirty" (i.e.  have changes that haven't been pushed) or are still awaiting confirmation of
     // storage of the most recent serialized push data.
     virtual bool needs_push() const;
 
-    // Returns the data messages to push to the server along with the seqno value of the data.  If
-    // the config is currently dirty (i.e. has previously unsent modifications) then this marks it
-    // as awaiting-confirmation instead of dirty so that any future change immediately increments
-    // the seqno.
+    // Returns a tuple of three elements:
+    // - the seqno value of the data
+    // - the data message to push to the server
+    // - a list of known message hashes that are obsoleted by this push.
+    //
+    // Additionally, if the internal state is currently dirty (i.e. there are unpushed changes), the
+    // internal state will be marked as awaiting-confirmation.  Any further data changes made after
+    // this call will re-dirty the data (incrementing seqno and requiring another push).
+    //
+    // The client is expected to send a sequence request to the server that stores the message and
+    // deletes the hashes (if any).  It is strongly recommended to use a sequence rather than a
+    // batch so that the deletions won't happen if the store fails for some reason.
+    //
+    // Upon successful completion of the store+deletion requests the client should call
+    // `confirm_pushed` with the seqno value to confirm that the message has been stored.
     //
     // Subclasses that need to perform pre-push tasks (such as pruning stale data) can override this
     // to prune and then call the base method to perform the actual push generation.
-    virtual std::pair<ustring, seqno_t> push();
+    virtual std::tuple<seqno_t, ustring, std::vector<std::string>> push();
 
     // Should be called after the push is confirmed stored on the storage server swarm to let the
-    // object know the data is stored.  (Once this is called `needs_push` will start returning false
-    // until something changes).  Takes the seqno that was pushed so that the object can ensure that
-    // the latest version was pushed (i.e. in case there have been other changes since the `push()`
-    // call that returned this seqno).
+    // object know the config message has been stored and, ideally, that the obsolete messages
+    // returned by `push()` are deleted.  Once this is called `needs_push` will start returning
+    // false until something changes.  Takes the seqno that was pushed so that the object can ensure
+    // that the latest version was pushed (i.e. in case there have been other changes since the
+    // `push()` call that returned this seqno).
+    //
+    // Ideally the caller should have both stored the returned message and deleted the given
+    // messages.  The deletion step isn't critical (it is just cleanup) and callers should call this
+    // as long as the store succeeded even if there were errors in the deletions.
     //
     // It is safe to call this multiple times with the same seqno value, and with out-of-order
     // seqnos (e.g. calling with seqno 122 after having called with 123; the duplicates and earlier
     // ones will just be ignored).
-    virtual void confirm_pushed(seqno_t seqno);
+    virtual void confirm_pushed(seqno_t seqno, std::string msg_hash);
 
     // Returns a dump of the current state for storage in the database; this value would get passed
     // into the constructor to reconstitute the object (including the push/not pushed status).  This

--- a/include/session/config/base.hpp
+++ b/include/session/config/base.hpp
@@ -488,9 +488,9 @@ class ConfigBase {
     // unmodified).
     bool is_clean() const { return _state == ConfigState::Clean; }
 
-    // The current config hash; this will be empty if the current hash is unknown or the current
-    // state is not clean.
-    const std::string& current_hash() const { return _curr_hash; }
+    // The current config hash(es); this can be empty if the current hash is unknown or the current
+    // state is not clean (i.e. a push is needed or pending).
+    std::vector<std::string> current_hashes() const;
 
     // Returns true if this object contains updated data that has not yet been confirmed stored on
     // the server.  This will be true whenever `is_clean()` is false: that is, if we are currently

--- a/include/session/config/community.h
+++ b/include/session/config/community.h
@@ -31,7 +31,11 @@ bool community_parse_full_url(
 // may be NULL in which case it is not set (typically both pubkey arguments would be null for cases
 // where you don't care at all about the pubkey).
 bool community_parse_partial_url(
-        const char* full_url, char* base_url, char* room_token, unsigned char* pubkey, bool* has_pubkey);
+        const char* full_url,
+        char* base_url,
+        char* room_token,
+        unsigned char* pubkey,
+        bool* has_pubkey);
 
 // Produces a standard full URL from a given base_url (c string), room token (c string), and pubkey
 // (fixed-length 32 byte buffer).  The full URL is written to `full_url`, which must be at least

--- a/include/session/config/community.h
+++ b/include/session/config/community.h
@@ -25,6 +25,14 @@ extern const size_t COMMUNITY_FULL_URL_MAX_LENGTH;
 bool community_parse_full_url(
         const char* full_url, char* base_url, char* room_token, unsigned char* pubkey);
 
+// Similar to the above, but allows a URL to omit the pubkey.  If no pubkey is found, `pubkey` is
+// left unchanged and `has_pubkey` is set to false; otherwise `pubkey` is written and `has_pubkey`
+// is set to true.  `pubkey` may be set to NULL, in which case it is never written.  `has_pubkey`
+// may be NULL in which case it is not set (typically both pubkey arguments would be null for cases
+// where you don't care at all about the pubkey).
+bool community_parse_partial_url(
+        const char* full_url, char* base_url, char* room_token, unsigned char* pubkey, bool* has_pubkey);
+
 // Produces a standard full URL from a given base_url (c string), room token (c string), and pubkey
 // (fixed-length 32 byte buffer).  The full URL is written to `full_url`, which must be at least
 // COMMUNITY_FULL_URL_MAX_LENGTH in size.

--- a/include/session/config/community.h
+++ b/include/session/config/community.h
@@ -4,6 +4,7 @@
 extern "C" {
 #endif
 
+#include <stdbool.h>
 #include <stddef.h>
 
 // Maximum string length of a community base URL

--- a/include/session/config/community.hpp
+++ b/include/session/config/community.hpp
@@ -125,6 +125,11 @@ struct community {
     // Throw std::invalid_argument if anything in the URL is unparseable or invalid.
     static std::tuple<std::string, std::string, ustring> parse_full_url(std::string_view full_url);
 
+    // Takes a full or partial room URL (partial here meaning missing the ?public_key=...) and
+    // splits it up into canonical url, room, and (if present) pubkey.
+    static std::tuple<std::string, std::string, std::optional<ustring>> parse_partial_url(
+            std::string_view url);
+
   protected:
     // The canonical base url and room (i.e. lower-cased, URL cleaned up):
     std::string base_url_, room_;

--- a/include/session/config/convo_info_volatile.hpp
+++ b/include/session/config/convo_info_volatile.hpp
@@ -136,7 +136,7 @@ class ConvoInfoVolatile : public ConfigBase {
     static constexpr auto PRUNE_HIGH = 45 * 24h;
 
     /// Overrides push() to prune stale last-read values before we do the push.
-    std::pair<ustring, seqno_t> push() override;
+    std::tuple<seqno_t, ustring, std::vector<std::string>> push() override;
 
     /// Looks up and returns a contact by session ID (hex).  Returns nullopt if the session ID was
     /// not found, otherwise returns a filled out `convo::one_to_one`.

--- a/include/session/config/convo_info_volatile.hpp
+++ b/include/session/config/convo_info_volatile.hpp
@@ -148,10 +148,9 @@ class ConvoInfoVolatile : public ConfigBase {
     std::optional<convo::community> get_community(
             std::string_view base_url, std::string_view room) const;
 
-    /// Shortcut for calling community::parse_full_url then calling the above with the base url and
-    /// room.  Note that pubkey must be present to successfully parse, but is ignored (and so the
-    /// pubkey in the returned result *could* be different in unusual cases).
-    std::optional<convo::community> get_community(std::string_view full_url) const;
+    /// Shortcut for calling community::parse_partial_url then calling the above with the base url
+    /// and room.  The URL is not required to contain the pubkey (if present it will be ignored).
+    std::optional<convo::community> get_community(std::string_view partial_url) const;
 
     /// Looks up and returns a legacy group conversation by ID.  The ID looks like a hex Session ID,
     /// but isn't really a Session ID.  Returns nullopt if there is no record of the group

--- a/include/session/config/user_groups.h
+++ b/include/session/config/user_groups.h
@@ -10,6 +10,9 @@ extern "C" {
 // Maximum length of a group name, in bytes
 extern const size_t GROUP_NAME_MAX_LENGTH;
 
+/// Struct holding legacy group info; this struct owns allocated memory and *must* be freed via
+/// either `ugroups_legacy_group_free()` or `user_groups_set_free_legacy_group()` when finished with
+/// it.
 typedef struct ugroups_legacy_group_info {
     char session_id[67];  // in hex; 66 hex chars + null terminator.
 
@@ -26,6 +29,10 @@ typedef struct ugroups_legacy_group_info {
     bool hidden;                 // true if hidden from the convo list
     int priority;  // pinned message priority; 0 = unpinned, larger means pinned higher (i.e. higher
                    // priority conversations come first).
+
+    // For members use the ugroups_legacy_group_members and associated calls.
+
+    void* _internal;  // Internal storage, do not touch.
 } ugroups_legacy_group_info;
 
 typedef struct ugroups_community_info {
@@ -76,34 +83,98 @@ bool user_groups_get_or_construct_community(
         const char* room,
         unsigned const char* pubkey) __attribute__((warn_unused_result));
 
-/// Fills `group` with the conversation info given a legacy group ID (specified as a null-terminated
-/// hex string), if the conversation exists, and returns true.  If the conversation does not exist
-/// then `group` is left unchanged and false is returned.
-bool user_groups_get_legacy_group(
-        const config_object* conf, ugroups_legacy_group_info* group, const char* id)
+/// Returns a ugroups_legacy_group_info pointer containing the conversation info for a given legacy
+/// group ID (specified as a null-terminated hex string), if the conversation exists.  If the
+/// conversation does not exist, returns NULL.
+///
+/// The returned pointer *must* be freed either by calling `ugroups_legacy_group_free()` when done
+/// with it, or by passing it to `user_groups_set_free_legacy_group()`.
+ugroups_legacy_group_info* user_groups_get_legacy_group(const config_object* conf, const char* id)
         __attribute__((warn_unused_result));
 
 /// Same as the above except that when the conversation does not exist, this sets all the group
 /// fields to defaults and loads it with the given id.
 ///
-/// Returns true as long as it is given a valid legacy group group id (i.e. same format as a session
-/// id).  A false return is considered an error, and means the id was not a valid session id.
+/// Returns a ugroups_legacy_group_info as long as it is given a valid legacy group id (i.e. same
+/// format as a session id); it will return NULL only if the given id is invalid (and so the caller
+/// needs to either pre-validate the id, or post-validate the return value).
+///
+/// The returned pointer *must* be freed either by calling `ugroups_legacy_group_free()` when done
+/// with it, or by passing it to `user_groups_set_free_legacy_group()`.
 ///
 /// This is the method that should usually be used to create or update a conversation, followed by
 /// setting fields in the group, and then giving it to user_groups_set().
-bool user_groups_get_or_construct_legacy_group(
-        const config_object* conf, ugroups_legacy_group_info* group, const char* id)
-        __attribute__((warn_unused_result));
+ugroups_legacy_group_info* user_groups_get_or_construct_legacy_group(
+        const config_object* conf, const char* id) __attribute__((warn_unused_result));
 
-/// Adds or updates a conversation from the given group info
+/// Properly frees memory associated with a ugroups_legacy_group_info pointer (as returned by
+/// get_legacy_group/get_or_construct_legacy_group).
+void ugroups_legacy_group_free(ugroups_legacy_group_info* group);
+
+/// Adds or updates a community conversation from the given group info
 void user_groups_set_community(config_object* conf, const ugroups_community_info* group);
+
+/// Adds or updates a legacy group conversation from the into.  This version of the method should
+/// only be used when you explicitly want the `group` to remain valid; if the set is the last thing
+/// you need to do with it (which is common) it is more efficient to call the freeing version,
+/// below.
 void user_groups_set_legacy_group(config_object* conf, const ugroups_legacy_group_info* group);
+
+/// Same as above, except that this also frees the pointer for you, which is commonly what is wanted
+/// when updating fields.  This is equivalent to, but more efficient than, setting and then freeing.
+void user_groups_set_free_legacy_group(config_object* conf, ugroups_legacy_group_info* group);
 
 /// Erases a conversation from the conversation list.  Returns true if the conversation was found
 /// and removed, false if the conversation was not present.  You must not call this during
 /// iteration; see details below.
 bool user_groups_erase_community(config_object* conf, const char* base_url, const char* room);
 bool user_groups_erase_legacy_group(config_object* conf, const char* group_id);
+
+typedef struct ugroups_legacy_members_iterator ugroups_legacy_members_iterator;
+
+/// Group member iteration; this lets you walk through the full group member list.  Example usage:
+///
+///     const char* session_id;
+///     bool admin;
+///     ugroups_legacy_members_iterator* it = ugroups_legacy_members_begin(legacy_info);
+///     while (ugroups_legacy_members_next(it, &session_id, &admin)) {
+///         if (admin)
+///             printf("ADMIN: %s", session_id);
+///     }
+///     ugroups_legacy_members_free(it);
+///
+ugroups_legacy_members_iterator* ugroups_legacy_members_begin(ugroups_legacy_group_info* group);
+bool ugroups_legacy_members_next(
+        ugroups_legacy_members_iterator* it, const char** session_id, bool* admin);
+void ugroups_legacy_members_free(ugroups_legacy_members_iterator* it);
+
+/// This erases the group member at the current iteration location during a member iteration,
+/// allowing iteration to continue.
+///
+/// Example:
+///
+///     while (ugroups_legacy_members_next(it, &sid, &admin)) {
+///         if (should_remove(sid))
+///             ugroups_legacy_members_erase(it);
+///     }
+void ugroups_legacy_members_erase(ugroups_legacy_members_iterator* it);
+
+/// Adds a member (by session id and admin status) to this group.  Returns true if the member was
+/// inserted or had the admin status changed, false if the member already existed with the given
+/// status, or if the session_id is not valid.
+bool ugroups_legacy_member_add(
+        ugroups_legacy_group_info* group, const char* session_id, bool admin);
+
+/// Removes a member (including admins) from the group given the member's session id.  This is not
+/// safe to use on the current member during member iteration; for that see the above method
+/// instead.  Returns true if the session id was found and removed, false if not found.
+bool ugroups_legacy_member_remove(ugroups_legacy_group_info* group, const char* session_id);
+
+/// Accesses the number of members in the group.  The overall number is returned (both admins and
+/// non-admins); if the given variables are not NULL, they will be populated with the individual
+/// counts of members/admins.
+size_t ugroups_legacy_members_count(
+        const ugroups_legacy_group_info* group, size_t* members, size_t* admins);
 
 /// Returns the number of conversations.
 size_t user_groups_size(const config_object* conf);

--- a/include/session/config/user_groups.hpp
+++ b/include/session/config/user_groups.hpp
@@ -88,13 +88,21 @@ struct legacy_group_info {
 
     // Internal ctor/method for C API implementations:
     legacy_group_info(const struct ugroups_legacy_group_info& c);  // From c struct
-    void into(struct ugroups_legacy_group_info& c) const;          // Into c struct
+    legacy_group_info(struct ugroups_legacy_group_info&& c);       // From c struct
+    void into(struct ugroups_legacy_group_info& c) const&;         // Copy into c struct
+    void into(struct ugroups_legacy_group_info& c) &&;             // Move into c struct
 
   private:
     // session_id => (is admin)
     std::map<std::string, bool> members_;
 
     friend class UserGroups;
+
+    // Private implementations of the to/from C struct methods
+    struct impl_t {};
+    static constexpr inline impl_t impl{};
+    legacy_group_info(const struct ugroups_legacy_group_info& c, impl_t);
+    void into(struct ugroups_legacy_group_info& c, impl_t) const;
 
     void load(const dict& info_dict);
 };

--- a/include/session/config/user_groups.hpp
+++ b/include/session/config/user_groups.hpp
@@ -162,10 +162,9 @@ class UserGroups : public ConfigBase {
     std::optional<community_info> get_community(
             std::string_view base_url, std::string_view room) const;
 
-    /// Looks up a community from a full URL.  Note that the pubkey in the full URL must be present
-    /// (to properly parse), but is not used (i.e. you get back whatever pubkey is stored for that
-    /// room even if it doesn't match what you provided).
-    std::optional<community_info> get_community(std::string_view full_url) const;
+    /// Looks up a community from a full URL.  It is permitted for the URL to omit the pubkey (it
+    /// is not used or needed by this call).
+    std::optional<community_info> get_community(std::string_view partial_url) const;
 
     /// Looks up and returns a legacy group by group ID (hex, looks like a Session ID).  Returns
     /// nullopt if the group was not found, otherwise returns a filled out `legacy_group_info`.

--- a/src/config/base.cpp
+++ b/src/config/base.cpp
@@ -539,7 +539,7 @@ LIBSESSION_EXPORT bool config_needs_dump(const config_object* conf) {
 LIBSESSION_EXPORT config_string_list* config_current_hashes(const config_object* conf) {
     auto hashes = unbox(conf)->current_hashes();
     size_t sz = sizeof(config_string_list) + hashes.size() * sizeof(char*);
-    for (auto&h : hashes)
+    for (auto& h : hashes)
         sz += h.size() + 1;
     void* buf = std::malloc(sz);
     auto* ret = static_cast<config_string_list*>(buf);

--- a/src/config/community.cpp
+++ b/src/config/community.cpp
@@ -189,7 +189,8 @@ std::string community::canonical_room(std::string_view room) {
     return r;
 }
 
-std::tuple<std::string, std::string, std::optional<ustring>> community::parse_partial_url(std::string_view url) {
+std::tuple<std::string, std::string, std::optional<ustring>> community::parse_partial_url(
+        std::string_view url) {
     std::tuple<std::string, std::string, std::optional<ustring>> result;
     auto& [base_url, room_token, maybe_pubkey] = result;
 
@@ -249,7 +250,11 @@ LIBSESSION_C_API bool community_parse_full_url(
 }
 
 LIBSESSION_C_API bool community_parse_partial_url(
-        const char* full_url, char* base_url, char* room_token, unsigned char* pubkey, bool* has_pubkey) {
+        const char* full_url,
+        char* base_url,
+        char* room_token,
+        unsigned char* pubkey,
+        bool* has_pubkey) {
     try {
         auto [base, room, maybe_pk] = session::config::community::parse_partial_url(full_url);
         assert(base.size() <= COMMUNITY_BASE_URL_MAX_LENGTH);

--- a/src/config/community.cpp
+++ b/src/config/community.cpp
@@ -189,31 +189,37 @@ std::string community::canonical_room(std::string_view room) {
     return r;
 }
 
-std::tuple<std::string, std::string, ustring> community::parse_full_url(std::string_view full_url) {
-    std::tuple<std::string, std::string, ustring> result;
-    auto& [base_url, room_token, pubkey] = result;
+std::tuple<std::string, std::string, std::optional<ustring>> community::parse_partial_url(std::string_view url) {
+    std::tuple<std::string, std::string, std::optional<ustring>> result;
+    auto& [base_url, room_token, maybe_pubkey] = result;
 
     // Consume the URL from back to front; first the public key:
-    if (auto pos = full_url.rfind(qs_pubkey); pos != std::string_view::npos) {
-        auto pk = full_url.substr(pos + qs_pubkey.size());
-        pubkey = decode_pubkey(pk);
-        full_url = full_url.substr(0, pos);
-    } else {
-        throw std::invalid_argument{"Invalid community URL: no valid server pubkey"};
+    if (auto pos = url.rfind(qs_pubkey); pos != std::string_view::npos) {
+        auto pk = url.substr(pos + qs_pubkey.size());
+        maybe_pubkey = decode_pubkey(pk);
+        url = url.substr(0, pos);
     }
 
     // Now look for /r/TOKEN or /TOKEN:
-    if (auto pos = full_url.rfind("/r/"); pos != std::string_view::npos) {
-        room_token = full_url.substr(pos + 3);
-        full_url = full_url.substr(0, pos);
-    } else if (pos = full_url.rfind("/"); pos != std::string_view::npos) {
-        room_token = full_url.substr(pos + 1);
-        full_url = full_url.substr(0, pos);
+    if (auto pos = url.rfind("/r/"); pos != std::string_view::npos) {
+        room_token = url.substr(pos + 3);
+        url = url.substr(0, pos);
+    } else if (pos = url.rfind("/"); pos != std::string_view::npos) {
+        room_token = url.substr(pos + 1);
+        url = url.substr(0, pos);
     }
 
-    base_url = canonical_url(full_url);
+    base_url = canonical_url(url);
 
     return result;
+}
+
+std::tuple<std::string, std::string, ustring> community::parse_full_url(std::string_view full_url) {
+    auto [base, rm, maybe_pk] = parse_partial_url(full_url);
+    if (!maybe_pk)
+        throw std::invalid_argument{"Invalid community URL: no valid server pubkey"};
+
+    return {std::move(base), std::move(rm), std::move(*maybe_pk)};
 }
 
 }  // namespace session::config
@@ -236,6 +242,25 @@ LIBSESSION_C_API bool community_parse_full_url(
         std::memcpy(base_url, base.data(), base.size() + 1);
         std::memcpy(room_token, room.data(), room.size() + 1);
         std::memcpy(pubkey, pk.data(), pk.size());
+        return true;
+    } catch (...) {
+    }
+    return false;
+}
+
+LIBSESSION_C_API bool community_parse_partial_url(
+        const char* full_url, char* base_url, char* room_token, unsigned char* pubkey, bool* has_pubkey) {
+    try {
+        auto [base, room, maybe_pk] = session::config::community::parse_partial_url(full_url);
+        assert(base.size() <= COMMUNITY_BASE_URL_MAX_LENGTH);
+        assert(room.size() <= COMMUNITY_ROOM_MAX_LENGTH);
+        assert(!maybe_pk || maybe_pk->size() == 32);
+        std::memcpy(base_url, base.data(), base.size() + 1);
+        std::memcpy(room_token, room.data(), room.size() + 1);
+        if (maybe_pk && pubkey)
+            std::memcpy(pubkey, maybe_pk->data(), maybe_pk->size());
+        if (has_pubkey)
+            *has_pubkey = maybe_pk.has_value();
         return true;
     } catch (...) {
     }

--- a/src/config/convo_info_volatile.cpp
+++ b/src/config/convo_info_volatile.cpp
@@ -127,7 +127,8 @@ std::optional<convo::community> ConvoInfoVolatile::get_community(
     return std::nullopt;
 }
 
-std::optional<convo::community> ConvoInfoVolatile::get_community(std::string_view partial_url) const {
+std::optional<convo::community> ConvoInfoVolatile::get_community(
+        std::string_view partial_url) const {
     auto [base, room, pubkey] = community::parse_partial_url(partial_url);
     return get_community(base, room);
 }

--- a/src/config/convo_info_volatile.cpp
+++ b/src/config/convo_info_volatile.cpp
@@ -199,7 +199,7 @@ void ConvoInfoVolatile::set_base(const convo::base& c, DictFieldProxy& info) {
     set_flag(info["u"], c.unread);
 }
 
-std::pair<ustring, seqno_t> ConvoInfoVolatile::push() {
+std::tuple<seqno_t, ustring, std::vector<std::string>> ConvoInfoVolatile::push() {
     // Prune off any conversations with last_read timestamps more than PRUNE_HIGH ago (unless they
     // also have a `unread` flag set, in which case we keep them indefinitely).
     const int64_t cutoff =

--- a/src/config/convo_info_volatile.cpp
+++ b/src/config/convo_info_volatile.cpp
@@ -127,8 +127,8 @@ std::optional<convo::community> ConvoInfoVolatile::get_community(
     return std::nullopt;
 }
 
-std::optional<convo::community> ConvoInfoVolatile::get_community(std::string_view full_url) const {
-    auto [base, room, pubkey] = community::parse_full_url(full_url);
+std::optional<convo::community> ConvoInfoVolatile::get_community(std::string_view partial_url) const {
+    auto [base, room, pubkey] = community::parse_partial_url(partial_url);
     return get_community(base, room);
 }
 

--- a/src/config/user_groups.cpp
+++ b/src/config/user_groups.cpp
@@ -202,8 +202,8 @@ std::optional<community_info> UserGroups::get_community(
     return std::nullopt;
 }
 
-std::optional<community_info> UserGroups::get_community(std::string_view full_url) const {
-    auto [base, room, pubkey] = community::parse_full_url(full_url);
+std::optional<community_info> UserGroups::get_community(std::string_view partial_url) const {
+    auto [base, room, pubkey] = community::parse_partial_url(partial_url);
     return get_community(base, room);
 }
 

--- a/tests/test_config_user_groups.cpp
+++ b/tests/test_config_user_groups.cpp
@@ -508,7 +508,9 @@ TEST_CASE("User Groups members C API", "[config][groups][c]") {
 
     session::config::UserGroups c2{ustring_view{seed}, std::nullopt};
 
-    CHECK(c2.merge({{"fakehash1", ustring_view{to_push->config, to_push->config_len}}}) == 1);
+    std::vector<std::pair<std::string, ustring_view>> to_merge;
+    to_merge.emplace_back("fakehash1", ustring_view{to_push->config, to_push->config_len});
+    CHECK(c2.merge(to_merge) == 1);
 
     auto grp = c2.get_legacy_group(definitely_real_id);
     REQUIRE(grp);

--- a/tests/test_configdata.cpp
+++ b/tests/test_configdata.cpp
@@ -423,7 +423,7 @@ TEST_CASE("config message signature", "[config][signing]") {
                     nullptr,
                     ConfigMessage::DEFAULT_DIFF_LAGS,
                     false,
-                    [](const auto& exc) { throw exc; }),
+                    [](size_t, const auto& exc) { throw exc; }),
             config::config_error,
             Message("Config signature failed verification"));
 
@@ -609,7 +609,6 @@ TEST_CASE("config message deserialization", "[config][deserialization]") {
         {"int1"s, ""s},
         {"int2"s, ""s}
     });
-    CHECK_FALSE(m.merged());
     CHECK_FALSE(m.verified_signature());
 
     auto expected_data = data118;

--- a/tests/utils.hpp
+++ b/tests/utils.hpp
@@ -4,6 +4,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <cstddef>
+#include <set>
 #include <string>
 #include <string_view>
 
@@ -62,4 +63,14 @@ inline void log_msg(config_log_level lvl, const char* msg, void*) {
           : lvl == LOG_LEVEL_INFO    ? "Info"
                                      : "debug")
          << ": " << msg);
+}
+
+template <typename Container>
+std::set<typename Container::value_type> as_set(const Container& c) {
+    return {c.begin(), c.end()};
+}
+
+template <typename... T>
+std::set<std::common_type_t<T...>> make_set(T&&... args) {
+    return {std::forward<T>(args)...};
 }


### PR DESCRIPTION
This adds tracking of obsolete hashes.  Doing so requires reworking some of the APIs around merging/pushing to now take the hash.

Fixes #19 