### PR TITLE
Add created & joined_at fields

### DIFF
--- a/include/session/config/contacts.h
+++ b/include/session/config/contacts.h
@@ -30,6 +30,8 @@ typedef struct contacts_contact {
     CONVO_EXPIRATION_MODE exp_mode;
     int exp_seconds;
 
+    int64_t created;  // unix timestamp (seconds)
+
 } contacts_contact;
 
 /// Constructs a contacts config object and sets a pointer to it in `conf`.

--- a/include/session/config/contacts.hpp
+++ b/include/session/config/contacts.hpp
@@ -39,6 +39,8 @@ namespace session::config {
 ///         for the conversation with this contact; 1 for delete-after-send, and 2 for
 ///         delete-after-read.
 ///     E - Disappearing message timer, in seconds.  Omitted when `e` is omitted.
+///     j - Unix timestamp (seconds) when the contact was created ("j" to match user_groups
+///         equivalent "j"oined field). Omitted if 0.
 
 /// Struct containing contact info.
 struct contact_info {
@@ -57,6 +59,7 @@ struct contact_info {
                           // (i.e. pinned earlier in the pinned list).
     expiration_mode exp_mode = expiration_mode::none;  // The expiry time; none if not expiring.
     std::chrono::seconds exp_timer{0};                 // The expiration timer (in seconds)
+    int64_t created = 0;                               // Unix timestamp when this contact was added
 
     explicit contact_info(std::string sid);
 
@@ -133,6 +136,7 @@ class Contacts : public ConfigBase {
             std::string_view session_id,
             expiration_mode exp_mode,
             std::chrono::seconds expiration_timer = 0min);
+    void set_created(std::string_view session_id, int64_t timestamp);
 
     /// Removes a contact, if present.  Returns true if it was found and removed, false otherwise.
     /// Note that this removes all fields related to a contact, even fields we do not know about.

--- a/include/session/config/user_groups.h
+++ b/include/session/config/user_groups.h
@@ -29,6 +29,7 @@ typedef struct ugroups_legacy_group_info {
     bool hidden;                 // true if hidden from the convo list
     int priority;  // pinned message priority; 0 = unpinned, larger means pinned higher (i.e. higher
                    // priority conversations come first).
+    int64_t joined_at;  // unix timestamp when joined (or re-joined)
 
     // For members use the ugroups_legacy_group_members and associated calls.
 
@@ -45,6 +46,7 @@ typedef struct ugroups_community_info {
 
     int priority;  // pinned message priority; 0 = unpinned, larger means pinned higher (i.e. higher
                    // priority conversations come first).
+    int64_t joined_at;  // unix timestamp when joined (or re-joined)
 } ugroups_community_info;
 
 int user_groups_init(

--- a/tests/test_config_contacts.cpp
+++ b/tests/test_config_contacts.cpp
@@ -11,6 +11,8 @@
 using namespace std::literals;
 using namespace oxenc::literals;
 
+static constexpr int64_t created_ts = 1680064059;
+
 TEST_CASE("Contacts", "[config][contacts]") {
 
     const auto seed = "0123456789abcdef0123456789abcdef00000000000000000000000000000000"_hexbytes;
@@ -46,6 +48,7 @@ TEST_CASE("Contacts", "[config][contacts]") {
     CHECK_FALSE(c.approved_me);
     CHECK_FALSE(c.blocked);
     CHECK_FALSE(c.profile_picture);
+    CHECK(c.created == 0);
 
     CHECK_FALSE(contacts.needs_push());
     CHECK_FALSE(contacts.needs_dump());
@@ -55,6 +58,7 @@ TEST_CASE("Contacts", "[config][contacts]") {
     c.set_nickname("Joey");
     c.approved = true;
     c.approved_me = true;
+    c.created = created_ts;
 
     contacts.set(c);
 
@@ -98,6 +102,7 @@ TEST_CASE("Contacts", "[config][contacts]") {
     CHECK(x->approved_me);
     CHECK_FALSE(x->profile_picture);
     CHECK_FALSE(x->blocked);
+    CHECK(x->created == created_ts);
 
     auto another_id = "051111111111111111111111111111111111111111111111111111111111111111"sv;
     auto c2 = contacts2.get_or_construct(another_id);
@@ -240,11 +245,13 @@ TEST_CASE("Contacts (C API)", "[config][contacts][c]") {
     CHECK_FALSE(c.approved_me);
     CHECK_FALSE(c.blocked);
     CHECK(strlen(c.profile_pic.url) == 0);
+    CHECK(c.created == 0);
 
     strcpy(c.name, "Joe");
     strcpy(c.nickname, "Joey");
     c.approved = true;
     c.approved_me = true;
+    c.created = created_ts;
 
     contacts_set(conf, &c);
 
@@ -287,6 +294,7 @@ TEST_CASE("Contacts (C API)", "[config][contacts][c]") {
     CHECK(c3.approved_me);
     CHECK_FALSE(c3.blocked);
     CHECK(strlen(c3.profile_pic.url) == 0);
+    CHECK(c3.created == created_ts);
 
     auto another_id = "051111111111111111111111111111111111111111111111111111111111111111";
     REQUIRE(contacts_get_or_construct(conf, &c3, another_id));
@@ -296,6 +304,7 @@ TEST_CASE("Contacts (C API)", "[config][contacts][c]") {
     CHECK_FALSE(c3.approved_me);
     CHECK_FALSE(c3.blocked);
     CHECK(strlen(c3.profile_pic.url) == 0);
+    CHECK(c3.created == 0);
 
     contacts_set(conf2, &c3);
 

--- a/tests/test_config_user_groups.cpp
+++ b/tests/test_config_user_groups.cpp
@@ -13,6 +13,8 @@
 using namespace std::literals;
 using namespace oxenc::literals;
 
+static constexpr int64_t created_ts = 1680064059;
+
 TEST_CASE("Open Group URLs", "[config][community_urls]") {
 
     using namespace session::config;
@@ -113,6 +115,7 @@ TEST_CASE("User Groups", "[config][groups]") {
     CHECK(c.priority == 0);
     CHECK(c.name == "");
     CHECK(c.members().empty());
+    CHECK(c.joined_at == 0);
 
     CHECK_FALSE(groups.needs_push());
     CHECK_FALSE(groups.needs_dump());
@@ -129,6 +132,7 @@ TEST_CASE("User Groups", "[config][groups]") {
 
     c.name = "Englishmen";
     c.disappearing_timer = 60min;
+    c.joined_at = created_ts;
     CHECK(c.insert(users[0], false));
     CHECK(c.insert(users[1], true));
     CHECK(c.insert(users[2], false));
@@ -229,6 +233,7 @@ TEST_CASE("User Groups", "[config][groups]") {
     CHECK(c1.priority == 3);
     CHECK(c1.members() == expected_members);
     CHECK(c1.name == "Englishmen");
+    CHECK(c1.joined_at == created_ts);
 
     CHECK_FALSE(g2.needs_push());
     CHECK_FALSE(g2.needs_dump());
@@ -422,6 +427,8 @@ TEST_CASE("User Groups members C API", "[config][groups][c]") {
 
     ugroups_legacy_group_info* group =
             user_groups_get_or_construct_legacy_group(conf, definitely_real_id);
+    CHECK(group->joined_at == 0);
+    group->joined_at = created_ts;
 
     std::vector<std::string> users = {
             "050000000000000000000000000000000000000000000000000000000000000000"s,
@@ -534,6 +541,7 @@ TEST_CASE("User Groups members C API", "[config][groups][c]") {
     auto grp = c2.get_legacy_group(definitely_real_id);
     REQUIRE(grp);
     CHECK(grp->members() == expected_members);
+    CHECK(grp->joined_at == created_ts);
 }
 
 namespace Catch {


### PR DESCRIPTION
These are both unix timestamps:
- Contacts `created` is when the contact record was created.
- legacy and community group `joined_at` is similar: when the group was "created", i.e. joined.