### PR TITLE
Merge priority & hidden

### DIFF
--- a/include/session/config/contacts.h
+++ b/include/session/config/contacts.h
@@ -24,7 +24,6 @@ typedef struct contacts_contact {
     bool approved;
     bool approved_me;
     bool blocked;
-    bool hidden;
 
     int priority;
     CONVO_NOTIFY_MODE notifications;

--- a/include/session/config/contacts.hpp
+++ b/include/session/config/contacts.hpp
@@ -32,11 +32,10 @@ namespace session::config {
 ///     a - 1 if approved, omitted otherwise (int)
 ///     A - 1 if remote has approved me, omitted otherwise (int)
 ///     b - 1 if contact is blocked, omitted otherwise
-///     h - 1 if the conversation with this contact is hidden, omitted if visible.
 ///     @ - notification setting (int).  Omitted = use default setting; 1 = all; 2 = disabled.
 ///     ! - mute timestamp: if this is set then notifications are to be muted until the given unix
 ///         timestamp (seconds, not milliseconds).
-///     + - the conversation priority, for pinned messages.  Omitted means not pinned; otherwise an
+///     + - the conversation priority; -1 means hidden; omitted means not pinned; otherwise an
 ///         integer value >0, where a higher priority means the conversation is meant to appear
 ///         earlier in the pinned conversation list.
 ///     e - Disappearing messages expiration type.  Omitted if disappearing messages are not enabled
@@ -57,10 +56,10 @@ struct contact_info {
     bool approved = false;
     bool approved_me = false;
     bool blocked = false;
-    bool hidden = false;  // True if the conversation with this contact is not visible in the convo
-                          // list (typically because it has been deleted).
-    int priority = 0;     // If >0 then this message is pinned; higher values mean higher priority
-                          // (i.e. pinned earlier in the pinned list).
+    int priority = 0;  // If >0 then this message is pinned; higher values mean higher priority
+                       // (i.e. pinned earlier in the pinned list).  If negative then this
+                       // conversation is hidden.  Otherwise (0) this is a regular, unpinned
+                       // conversation.
     notify_mode notifications = notify_mode::defaulted;
     int64_t mute_until = 0;  // If non-zero, disable notifications until the given unix timestamp
                              // (overriding whatever the current `notifications` value is until the
@@ -138,7 +137,6 @@ class Contacts : public ConfigBase {
     void set_approved(std::string_view session_id, bool approved);
     void set_approved_me(std::string_view session_id, bool approved_me);
     void set_blocked(std::string_view session_id, bool blocked);
-    void set_hidden(std::string_view session_id, bool hidden);
     void set_priority(std::string_view session_id, int priority);
     void set_notifications(std::string_view session_id, notify_mode notifications);
     void set_expiry(

--- a/include/session/config/user_groups.h
+++ b/include/session/config/user_groups.h
@@ -27,9 +27,8 @@ typedef struct ugroups_legacy_group_info {
                                    // terminator).
 
     int64_t disappearing_timer;  // Minutes. 0 == disabled.
-    bool hidden;                 // true if hidden from the convo list
-    int priority;  // pinned message priority; 0 = unpinned, larger means pinned higher (i.e. higher
-                   // priority conversations come first).
+    int priority;  // pinned message priority; 0 = unpinned, negative = hidden, positive = pinned
+                   // (with higher meaning pinned higher).
     int64_t joined_at;                // unix timestamp when joined (or re-joined)
     CONVO_NOTIFY_MODE notifications;  // When the user wants notifications
     int64_t mute_until;  // Mute notifications until this timestamp (overrides `notifications`
@@ -48,8 +47,8 @@ typedef struct ugroups_community_info {
                          // info (that one is always forced lower-cased).
     unsigned char pubkey[32];  // 32 bytes (not terminated, can contain nulls)
 
-    int priority;  // pinned message priority; 0 = unpinned, larger means pinned higher (i.e. higher
-                   // priority conversations come first).
+    int priority;  // pinned message priority; 0 = unpinned, negative = hidden, positive = pinned
+                   // (with higher meaning pinned higher).
     int64_t joined_at;                // unix timestamp when joined (or re-joined)
     CONVO_NOTIFY_MODE notifications;  // When the user wants notifications
     int64_t mute_until;  // Mute notifications until this timestamp (overrides `notifications`

--- a/include/session/config/user_profile.h
+++ b/include/session/config/user_profile.h
@@ -50,17 +50,13 @@ user_profile_pic user_profile_get_pic(const config_object* conf);
 // Sets a user profile
 int user_profile_set_pic(config_object* conf, user_profile_pic pic);
 
-// Gets the current note-to-self priority level. Will always be >= 0.
+// Gets the current note-to-self priority level. Will be negative for hidden, 0 for unpinned, and >
+// 0 for pinned (with higher value = higher priority).
 int user_profile_get_nts_priority(const config_object* conf);
 
-// Sets the current note-to-self priority level. Should be >= 0 (negatives will be set to 0).
+// Sets the current note-to-self priority level. Set to -1 for hidden; 0 for unpinned, and > 0 for
+// higher priority in the conversation list.
 void user_profile_set_nts_priority(config_object* conf, int priority);
-
-// Gets the current note-to-self priority level. Will always be >= 0.
-bool user_profile_get_nts_hidden(const config_object* conf);
-
-// Sets the current note-to-self priority level. Should be >= 0 (negatives will be set to 0).
-void user_profile_set_nts_hidden(config_object* conf, bool hidden);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/include/session/config/user_profile.hpp
+++ b/include/session/config/user_profile.hpp
@@ -15,9 +15,7 @@ namespace session::config {
 /// p - user profile url
 /// q - user profile decryption key (binary)
 /// + - the priority value for the "Note to Self" pseudo-conversation (higher = higher in the
-///     conversation list).  Omitted when 0.
-/// h - the "hidden" value for the "Note to Self" pseudo-conversation (true = hide).  Omitted when
-///     false.
+///     conversation list).  Omitted when 0.  -1 means hidden.
 
 class UserProfile final : public ConfigBase {
 
@@ -57,18 +55,13 @@ class UserProfile final : public ConfigBase {
     void set_profile_pic(std::string_view url, ustring_view key);
     void set_profile_pic(profile_pic pic);
 
-    /// Gets the Note-to-self conversation priority.  Will always be >= 0.
+    /// Gets the Note-to-self conversation priority.  Negative means hidden; 0 means unpinned;
+    /// higher means higher priority (i.e. hidden in the convo list).
     int get_nts_priority() const;
 
-    /// Sets the Note-to-self conversation priority. Should be >= 0 (negatives will be set to 0).
+    /// Sets the Note-to-self conversation priority. -1 for hidden, 0 for unpinned, higher for
+    /// pinned higher.
     void set_nts_priority(int priority);
-
-    /// Gets the Note-to-self hidden flag; true means the Note-to-self "conversation" should be
-    /// hidden from the conversation list.
-    bool get_nts_hidden() const;
-
-    /// Sets or clears the `hidden` flag that hides the Note-to-self from the conversation list.
-    void set_nts_hidden(bool hidden);
 };
 
 }  // namespace session::config

--- a/src/config/user_profile.cpp
+++ b/src/config/user_profile.cpp
@@ -94,7 +94,7 @@ LIBSESSION_C_API int user_profile_set_pic(config_object* conf, user_profile_pic 
 }
 
 void UserProfile::set_nts_priority(int priority) {
-    set_positive_int(data["+"], priority);
+    set_nonzero_int(data["+"], priority);
 }
 
 int UserProfile::get_nts_priority() const {
@@ -107,20 +107,4 @@ LIBSESSION_C_API int user_profile_get_nts_priority(const config_object* conf) {
 
 LIBSESSION_C_API void user_profile_set_nts_priority(config_object* conf, int priority) {
     unbox<UserProfile>(conf)->set_nts_priority(priority);
-}
-
-void UserProfile::set_nts_hidden(bool hidden) {
-    set_flag(data["h"], hidden);
-}
-
-bool UserProfile::get_nts_hidden() const {
-    return (bool)data["h"].integer_or(0);
-}
-
-LIBSESSION_C_API bool user_profile_get_nts_hidden(const config_object* conf) {
-    return unbox<UserProfile>(conf)->get_nts_hidden();
-}
-
-LIBSESSION_C_API void user_profile_set_nts_hidden(config_object* conf, bool hidden) {
-    unbox<UserProfile>(conf)->set_nts_hidden(hidden);
 }

--- a/tests/test_config_user_groups.cpp
+++ b/tests/test_config_user_groups.cpp
@@ -112,7 +112,6 @@ TEST_CASE("User Groups", "[config][groups]") {
     auto c = groups.get_or_construct_legacy_group(definitely_real_id);
 
     CHECK(c.session_id == definitely_real_id);
-    CHECK_FALSE(c.hidden);
     CHECK(c.disappearing_timer == 0min);
     CHECK(c.enc_pubkey.empty());
     CHECK(c.enc_seckey.empty());
@@ -237,7 +236,6 @@ TEST_CASE("User Groups", "[config][groups]") {
     CHECK(to_hex(c1.enc_seckey) == oxenc::to_hex(lg_sk.begin(), lg_sk.begin() + 32));
     CHECK(c1.disappearing_timer == 60min);
     CHECK(c1.session_id == definitely_real_id);
-    CHECK_FALSE(c1.hidden);
     CHECK(c1.priority == 3);
     CHECK(c1.members() == expected_members);
     CHECK(c1.name == "Englishmen");


### PR DESCRIPTION
This reimplements the `hidden` conversation flag as a priority value of -1 rather than using a separate flag for it.  The downside is that you can't "hide" and preserve a priority, but we decided that would be more confusing than anything and so it is worth simplifying.

Effectively this now enforces a "hidden means unpinned" assumption that was awkward to impose when they were separate fields.