### PR TITLE
Add better error diagnostics on failure to C API

### DIFF
--- a/include/session/config/base.h
+++ b/include/session/config/base.h
@@ -16,8 +16,11 @@ typedef struct config_object {
     // Internal opaque object pointer; calling code should leave this alone.
     void* internals;
     // When an error occurs in the C API this string will be set to the specific error message.  May
-    // be NULL.
+    // be empty.
     const char* last_error;
+
+    // Sometimes used as the backing buffer for `last_error`.  Should not be touched externally.
+    char _error_buf[256];
 } config_object;
 
 // Common functions callable on any config instance:

--- a/include/session/config/contacts.h
+++ b/include/session/config/contacts.h
@@ -66,7 +66,7 @@ int contacts_init(
 /// Fills `contact` with the contact info given a session ID (specified as a null-terminated hex
 /// string), if the contact exists, and returns true.  If the contact does not exist then `contact`
 /// is left unchanged and false is returned.
-bool contacts_get(const config_object* conf, contacts_contact* contact, const char* session_id)
+bool contacts_get(config_object* conf, contacts_contact* contact, const char* session_id)
         __attribute__((warn_unused_result));
 
 /// Same as the above except that when the contact does not exist, this sets all the contact fields
@@ -78,7 +78,7 @@ bool contacts_get(const config_object* conf, contacts_contact* contact, const ch
 /// This is the method that should usually be used to create or update a contact, followed by
 /// setting fields in the contact, and then giving it to contacts_set().
 bool contacts_get_or_construct(
-        const config_object* conf, contacts_contact* contact, const char* session_id)
+        config_object* conf, contacts_contact* contact, const char* session_id)
         __attribute__((warn_unused_result));
 
 /// Adds or updates a contact from the given contact info struct.

--- a/include/session/config/convo_info_volatile.h
+++ b/include/session/config/convo_info_volatile.h
@@ -61,34 +61,39 @@ int convo_info_volatile_init(
 
 /// Fills `convo` with the conversation info given a session ID (specified as a null-terminated hex
 /// string), if the conversation exists, and returns true.  If the conversation does not exist then
-/// `convo` is left unchanged and false is returned.
+/// `convo` is left unchanged and false is returned.  If an error occurs, false is returned and
+/// `conf->last_error` will be set to non-NULL containing the error string (if no error occurs, such
+/// as in the case where the conversation merely doesn't exist, `last_error` will be set to NULL).
 bool convo_info_volatile_get_1to1(
-        const config_object* conf, convo_info_volatile_1to1* convo, const char* session_id)
+        config_object* conf, convo_info_volatile_1to1* convo, const char* session_id)
         __attribute__((warn_unused_result));
 
 /// Same as the above except that when the conversation does not exist, this sets all the convo
 /// fields to defaults and loads it with the given session_id.
 ///
 /// Returns true as long as it is given a valid session_id.  A false return is considered an error,
-/// and means the session_id was not a valid session_id.
+/// and means the session_id was not a valid session_id.  In such a case `conf->last_error` will be
+/// set to an error string.
 ///
 /// This is the method that should usually be used to create or update a conversation, followed by
 /// setting fields in the convo, and then giving it to convo_info_volatile_set().
 bool convo_info_volatile_get_or_construct_1to1(
-        const config_object* conf, convo_info_volatile_1to1* convo, const char* session_id)
+        config_object* conf, convo_info_volatile_1to1* convo, const char* session_id)
         __attribute__((warn_unused_result));
 
 /// community versions of the 1-to-1 functions:
 ///
 /// Gets a community convo info.  `base_url` and `room` are null-terminated c strings; pubkey is
 /// 32 bytes.  base_url and room will always be lower-cased (if not already).
+///
+/// Error handling works the same as the 1-to-1 version.
 bool convo_info_volatile_get_community(
-        const config_object* conf,
+        config_object* conf,
         convo_info_volatile_community* comm,
         const char* base_url,
         const char* room) __attribute__((warn_unused_result));
 bool convo_info_volatile_get_or_construct_community(
-        const config_object* conf,
+        config_object* conf,
         convo_info_volatile_community* convo,
         const char* base_url,
         const char* room,
@@ -96,21 +101,23 @@ bool convo_info_volatile_get_or_construct_community(
 
 /// Fills `convo` with the conversation info given a legacy group ID (specified as a null-terminated
 /// hex string), if the conversation exists, and returns true.  If the conversation does not exist
-/// then `convo` is left unchanged and false is returned.
+/// then `convo` is left unchanged and false is returned.  On error, false is returned and the error
+/// is set in conf->last_error (on non-error, last_error is cleared).
 bool convo_info_volatile_get_legacy_group(
-        const config_object* conf, convo_info_volatile_legacy_group* convo, const char* id)
+        config_object* conf, convo_info_volatile_legacy_group* convo, const char* id)
         __attribute__((warn_unused_result));
 
 /// Same as the above except that when the conversation does not exist, this sets all the convo
 /// fields to defaults and loads it with the given id.
 ///
 /// Returns true as long as it is given a valid legacy group id (i.e. same format as a session id).
-/// A false return is considered an error, and means the id was not a valid session id.
+/// A false return is considered an error, and means the id was not a valid session id; an error
+/// string will be set in `conf->last_error`.
 ///
 /// This is the method that should usually be used to create or update a conversation, followed by
 /// setting fields in the convo, and then giving it to convo_info_volatile_set().
 bool convo_info_volatile_get_or_construct_legacy_group(
-        const config_object* conf, convo_info_volatile_legacy_group* convo, const char* id)
+        config_object* conf, convo_info_volatile_legacy_group* convo, const char* id)
         __attribute__((warn_unused_result));
 
 /// Adds or updates a conversation from the given convo info

--- a/include/session/config/user_groups.h
+++ b/include/session/config/user_groups.h
@@ -67,12 +67,12 @@ int user_groups_init(
 /// normalized/lower-cased; room is case-insensitive for the lookup: note that this may well return
 /// a community info with a different room capitalization than the one provided to the call.
 ///
-/// Returns true if the community was found and `comm` populated; false otherwise.
+/// Returns true if the community was found and `comm` populated; false otherwise.  A false return
+/// can either be because it didn't exist (`conf->last_error` will be NULL) or because of some error
+/// (`last_error` will be set to an error string).
 bool user_groups_get_community(
-        const config_object* conf,
-        ugroups_community_info* comm,
-        const char* base_url,
-        const char* room) __attribute__((warn_unused_result));
+        config_object* conf, ugroups_community_info* comm, const char* base_url, const char* room)
+        __attribute__((warn_unused_result));
 
 /// Like the above, but if the community was not found, this constructs one that can be inserted.
 /// `base_url` will be normalized in the returned object.  `room` is a case-insensitive lookup key
@@ -84,8 +84,10 @@ bool user_groups_get_community(
 ///
 /// Note that this is all different from convo_info_volatile, which always forces the room token to
 /// lower-case (because it does not preserve the case).
+///
+/// Returns false (and sets `conf->last_error`) on error.
 bool user_groups_get_or_construct_community(
-        const config_object* conf,
+        config_object* conf,
         ugroups_community_info* comm,
         const char* base_url,
         const char* room,
@@ -93,11 +95,11 @@ bool user_groups_get_or_construct_community(
 
 /// Returns a ugroups_legacy_group_info pointer containing the conversation info for a given legacy
 /// group ID (specified as a null-terminated hex string), if the conversation exists.  If the
-/// conversation does not exist, returns NULL.
+/// conversation does not exist, returns NULL.  Sets conf->last_error on error.
 ///
 /// The returned pointer *must* be freed either by calling `ugroups_legacy_group_free()` when done
 /// with it, or by passing it to `user_groups_set_free_legacy_group()`.
-ugroups_legacy_group_info* user_groups_get_legacy_group(const config_object* conf, const char* id)
+ugroups_legacy_group_info* user_groups_get_legacy_group(config_object* conf, const char* id)
         __attribute__((warn_unused_result));
 
 /// Same as the above except that when the conversation does not exist, this sets all the group
@@ -112,8 +114,10 @@ ugroups_legacy_group_info* user_groups_get_legacy_group(const config_object* con
 ///
 /// This is the method that should usually be used to create or update a conversation, followed by
 /// setting fields in the group, and then giving it to user_groups_set().
+///
+/// On error, this returns NULL and sets `conf->last_error`.
 ugroups_legacy_group_info* user_groups_get_or_construct_legacy_group(
-        const config_object* conf, const char* id) __attribute__((warn_unused_result));
+        config_object* conf, const char* id) __attribute__((warn_unused_result));
 
 /// Properly frees memory associated with a ugroups_legacy_group_info pointer (as returned by
 /// get_legacy_group/get_or_construct_legacy_group).

--- a/src/config/contacts.cpp
+++ b/src/config/contacts.cpp
@@ -188,13 +188,16 @@ std::optional<contact_info> Contacts::get(std::string_view pubkey_hex) const {
 }
 
 LIBSESSION_C_API bool contacts_get(
-        const config_object* conf, contacts_contact* contact, const char* session_id) {
+        config_object* conf, contacts_contact* contact, const char* session_id) {
     try {
+        conf->last_error = nullptr;
         if (auto c = unbox<Contacts>(conf)->get(session_id)) {
             c->into(*contact);
             return true;
         }
-    } catch (...) {
+    } catch (const std::exception& e) {
+        copy_c_str(conf->_error_buf, e.what());
+        conf->last_error = conf->_error_buf;
     }
     return false;
 }
@@ -207,11 +210,14 @@ contact_info Contacts::get_or_construct(std::string_view pubkey_hex) const {
 }
 
 LIBSESSION_C_API bool contacts_get_or_construct(
-        const config_object* conf, contacts_contact* contact, const char* session_id) {
+        config_object* conf, contacts_contact* contact, const char* session_id) {
     try {
+        conf->last_error = nullptr;
         unbox<Contacts>(conf)->get_or_construct(session_id).into(*contact);
         return true;
-    } catch (...) {
+    } catch (const std::exception& e) {
+        copy_c_str(conf->_error_buf, e.what());
+        conf->last_error = conf->_error_buf;
         return false;
     }
 }

--- a/src/config/convo_info_volatile.cpp
+++ b/src/config/convo_info_volatile.cpp
@@ -427,75 +427,93 @@ int convo_info_volatile_init(
 }
 
 LIBSESSION_C_API bool convo_info_volatile_get_1to1(
-        const config_object* conf, convo_info_volatile_1to1* convo, const char* session_id) {
+        config_object* conf, convo_info_volatile_1to1* convo, const char* session_id) {
     try {
+        conf->last_error = nullptr;
         if (auto c = unbox<ConvoInfoVolatile>(conf)->get_1to1(session_id)) {
             c->into(*convo);
             return true;
         }
-    } catch (...) {
+    } catch (const std::exception& e) {
+        copy_c_str(conf->_error_buf, e.what());
+        conf->last_error = conf->_error_buf;
     }
     return false;
 }
 
 LIBSESSION_C_API bool convo_info_volatile_get_or_construct_1to1(
-        const config_object* conf, convo_info_volatile_1to1* convo, const char* session_id) {
+        config_object* conf, convo_info_volatile_1to1* convo, const char* session_id) {
     try {
+        conf->last_error = nullptr;
         unbox<ConvoInfoVolatile>(conf)->get_or_construct_1to1(session_id).into(*convo);
         return true;
-    } catch (...) {
+    } catch (const std::exception& e) {
+        copy_c_str(conf->_error_buf, e.what());
+        conf->last_error = conf->_error_buf;
         return false;
     }
 }
 
 LIBSESSION_C_API bool convo_info_volatile_get_community(
-        const config_object* conf,
+        config_object* conf,
         convo_info_volatile_community* og,
         const char* base_url,
         const char* room) {
     try {
+        conf->last_error = nullptr;
         if (auto c = unbox<ConvoInfoVolatile>(conf)->get_community(base_url, room)) {
             c->into(*og);
             return true;
         }
-    } catch (...) {
+    } catch (const std::exception& e) {
+        copy_c_str(conf->_error_buf, e.what());
+        conf->last_error = conf->_error_buf;
     }
     return false;
 }
 LIBSESSION_C_API bool convo_info_volatile_get_or_construct_community(
-        const config_object* conf,
+        config_object* conf,
         convo_info_volatile_community* convo,
         const char* base_url,
         const char* room,
         unsigned const char* pubkey) {
     try {
+        conf->last_error = nullptr;
         unbox<ConvoInfoVolatile>(conf)
                 ->get_or_construct_community(base_url, room, ustring_view{pubkey, 32})
                 .into(*convo);
         return true;
-    } catch (...) {
+    } catch (const std::exception& e) {
+        copy_c_str(conf->_error_buf, e.what());
+        conf->last_error = conf->_error_buf;
         return false;
     }
 }
 
 LIBSESSION_C_API bool convo_info_volatile_get_legacy_group(
-        const config_object* conf, convo_info_volatile_legacy_group* convo, const char* id) {
+        config_object* conf, convo_info_volatile_legacy_group* convo, const char* id) {
     try {
+        conf->last_error = nullptr;
         if (auto c = unbox<ConvoInfoVolatile>(conf)->get_legacy_group(id)) {
             c->into(*convo);
             return true;
         }
-    } catch (...) {
+    } catch (const std::exception& e) {
+        copy_c_str(conf->_error_buf, e.what());
+        conf->last_error = conf->_error_buf;
     }
     return false;
 }
 
 LIBSESSION_C_API bool convo_info_volatile_get_or_construct_legacy_group(
-        const config_object* conf, convo_info_volatile_legacy_group* convo, const char* id) {
+        config_object* conf, convo_info_volatile_legacy_group* convo, const char* id) {
     try {
+        conf->last_error = nullptr;
         unbox<ConvoInfoVolatile>(conf)->get_or_construct_legacy_group(id).into(*convo);
         return true;
-    } catch (...) {
+    } catch (const std::exception& e) {
+        copy_c_str(conf->_error_buf, e.what());
+        conf->last_error = conf->_error_buf;
         return false;
     }
 }

--- a/src/config/user_groups.cpp
+++ b/src/config/user_groups.cpp
@@ -469,31 +469,34 @@ int user_groups_init(
 }
 
 LIBSESSION_C_API bool user_groups_get_community(
-        const config_object* conf,
-        ugroups_community_info* comm,
-        const char* base_url,
-        const char* room) {
+        config_object* conf, ugroups_community_info* comm, const char* base_url, const char* room) {
     try {
+        conf->last_error = nullptr;
         if (auto c = unbox<UserGroups>(conf)->get_community(base_url, room)) {
             c->into(*comm);
             return true;
         }
-    } catch (...) {
+    } catch (const std::exception& e) {
+        copy_c_str(conf->_error_buf, e.what());
+        conf->last_error = conf->_error_buf;
     }
     return false;
 }
 LIBSESSION_C_API bool user_groups_get_or_construct_community(
-        const config_object* conf,
+        config_object* conf,
         ugroups_community_info* comm,
         const char* base_url,
         const char* room,
         unsigned const char* pubkey) {
     try {
+        conf->last_error = nullptr;
         unbox<UserGroups>(conf)
                 ->get_or_construct_community(base_url, room, ustring_view{pubkey, 32})
                 .into(*comm);
         return true;
-    } catch (...) {
+    } catch (const std::exception& e) {
+        copy_c_str(conf->_error_buf, e.what());
+        conf->last_error = conf->_error_buf;
         return false;
     }
 }
@@ -506,27 +509,33 @@ LIBSESSION_C_API void ugroups_legacy_group_free(ugroups_legacy_group_info* group
 }
 
 LIBSESSION_C_API ugroups_legacy_group_info* user_groups_get_legacy_group(
-        const config_object* conf, const char* id) {
+        config_object* conf, const char* id) {
     try {
+        conf->last_error = nullptr;
         auto group = std::make_unique<ugroups_legacy_group_info>();
         group->_internal = nullptr;
         if (auto c = unbox<UserGroups>(conf)->get_legacy_group(id)) {
             std::move(c)->into(*group);
             return group.release();
         }
-    } catch (...) {
+    } catch (const std::exception& e) {
+        copy_c_str(conf->_error_buf, e.what());
+        conf->last_error = conf->_error_buf;
     }
     return nullptr;
 }
 
 LIBSESSION_C_API ugroups_legacy_group_info* user_groups_get_or_construct_legacy_group(
-        const config_object* conf, const char* id) {
+        config_object* conf, const char* id) {
     try {
+        conf->last_error = nullptr;
         auto group = std::make_unique<ugroups_legacy_group_info>();
         group->_internal = nullptr;
         unbox<UserGroups>(conf)->get_or_construct_legacy_group(id).into(*group);
         return group.release();
-    } catch (...) {
+    } catch (const std::exception& e) {
+        copy_c_str(conf->_error_buf, e.what());
+        conf->last_error = conf->_error_buf;
         return nullptr;
     }
 }


### PR DESCRIPTION
The C++ API throws exceptions, but these were just being squelched into a single bool return; this changes most such places to also set `conf->last_error` to the error message when such an error occurs (and to clear `conf->last_error` when no error occurs).