### PR TITLE
Fix assigning empty dicts/sets dirtying

### DIFF
--- a/include/session/config/user_groups.hpp
+++ b/include/session/config/user_groups.hpp
@@ -219,8 +219,6 @@ class UserGroups : public ConfigBase {
     ///
     void set(const community_info& info);
     void set(const legacy_group_info& info);
-    /// Takes a variant of either group type to set:
-    void set(const any_group_info& info);
 
   protected:
     // Drills into the nested dicts to access open group details


### PR DESCRIPTION
When assigning an empty set/dict to a location that doesn't currently exist, we'd dirty the config, assign the empty dict/set, but then when we produce the update it is unchanged because empty dicts/sets get pruned.

This fixes it so that such assignment becomes an *erase* instead, since that what the final result will be.