### PR TITLE
Update android ndk deb

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -316,7 +316,6 @@ local static_build(name,
   debian_pipeline(
     'Static Android',
     docker_base + 'android',
-    deps=['google-android-ndk-installer'],
     build=[
       'export JOBS=6',
       'export NDK=/usr/lib/android-ndk',


### PR DESCRIPTION
Getting this error from the CI
```
Package google-android-ndk-installer is not available, but is referred to by another package.

This may mean that the package is missing, has been obsoleted, or

is only available from another source

However the following packages replace it:

  google-android-ndk-r25c-installer
```

android-ndk-r25c is the current long term release according to https://github.com/android/ndk/wiki and it appears that the source repos have depreciated the general package for specific versions. Going forward this will need to be kept up to date