### PR TITLE
update wine64 command

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -152,7 +152,7 @@ local windows_cross_pipeline(name,
                    commands: [
                      apt_get_quiet + ' install -y --no-install-recommends wine64',
                      'cd build',
-                     'wine64-stable ./tests/testAll.exe --colour-mode ansi',
+                     '/usr/lib/wine/wine64 ./tests/testAll.exe --colour-mode ansi',
                    ],
                  }] else [])
 );


### PR DESCRIPTION
Appears that bookworm moved the binary for wine64
**https://packages.debian.org/bookworm/amd64/wine64/filelist**