### PR TITLE
Remove broken erase(iterator) interface

### DIFF
--- a/include/session/config/contacts.h
+++ b/include/session/config/contacts.h
@@ -223,26 +223,7 @@ typedef struct contacts_iterator {
 ///     }
 ///     contacts_iterator_free(it);
 ///
-/// It is permitted to modify records (e.g. with a call to `contacts_set`) and add records while
-/// iterating.
-///
-/// If you need to remove while iterating then usage is slightly different: you must advance the
-/// iteration by calling either contacts_iterator_advance if not deleting, or
-/// contacts_iterator_erase to erase and advance.  Usage looks like this:
-///
-///     contacts_contact c;
-///     contacts_iterator *it = contacts_iterator_new(contacts);
-///     while (!contacts_iterator_done(it, &c)) {
-///         // c.session_id, c.nickname, etc. are loaded
-///
-///         bool should_delete = /* ... */;
-///
-///         if (should_delete)
-///             contacts_iterator_erase(it);
-///         else
-///             contacts_iterator_advance(it);
-///     }
-///     contacts_iterator_free(it);
+/// It is NOT permitted to add/remove/modify records while iterating.
 ///
 /// Declaration:
 /// ```cpp
@@ -314,26 +295,6 @@ LIBSESSION_EXPORT bool contacts_iterator_done(contacts_iterator* it, contacts_co
 /// Outputs:
 /// - `void` -- Nothing Returned
 LIBSESSION_EXPORT void contacts_iterator_advance(contacts_iterator* it);
-
-/// API: contacts/contacts_iterator_erase
-///
-/// Erases the current contact while advancing the iterator to the next contact in the iteration.
-///
-/// Declaration:
-/// ```cpp
-/// VOID contacts_iterator_erase(
-///     [in]    config_object*      conf,
-///     [in]    contacts_iterator*  it
-/// );
-/// ```
-///
-/// Inputs:
-/// - `conf` -- [in] Pointer to the config object
-/// - `it` -- [in] Pointer to the contacts_iterator
-///
-/// Outputs:
-/// - `void` -- Nothing Returned
-LIBSESSION_EXPORT void contacts_iterator_erase(config_object* conf, contacts_iterator* it);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/include/session/config/contacts.hpp
+++ b/include/session/config/contacts.hpp
@@ -442,27 +442,6 @@ class Contacts : public ConfigBase {
     /// - `bool` - Returns true if contact was found and removed, false otherwise
     bool erase(std::string_view session_id);
 
-    struct iterator;
-
-    /// API: contacts/contacts::erase(iterator)
-    ///
-    /// This works like erase, but takes an iterator to the contact to remove.  The element is
-    /// removed and the iterator to the next element after the removed one is returned.  This is
-    /// intended for use where elements are to be removed during iteration: see below for an
-    /// example.
-    ///
-    /// Declaration:
-    /// ```cpp
-    /// iterator erase(iterator it);
-    /// ```
-    ///
-    /// Inputs:
-    /// - `it` -- iterator resolving to the contact to remove
-    ///
-    /// Outputs:
-    /// - `iterator` - Returns the next element after the removed one
-    iterator erase(iterator it);
-
     /// API: contacts/contacts::size
     ///
     /// Returns the number of contacts.
@@ -493,6 +472,7 @@ class Contacts : public ConfigBase {
     /// - `bool` - Returns true if the contact list is empty
     bool empty() const { return size() == 0; }
 
+    struct iterator;
     /// API: contacts/contacts::begin
     ///
     /// Iterators for iterating through all contacts.  Typically you access this implicit via a for
@@ -506,25 +486,9 @@ class Contacts : public ConfigBase {
     ///
     /// This iterates in sorted order through the session_ids.
     ///
-    /// It is permitted to modify and add records while iterating (e.g. by modifying `contact` and
-    /// then calling set()).
-    ///
-    /// If you need to erase the current contact during iteration then care is required: you need to
-    /// advance the iterator via the iterator version of erase when erasing an element rather than
-    /// incrementing it regularly.  For example:
-    ///
-    ///```cpp
-    ///     for (auto it = contacts.begin(); it != contacts.end(); ) {
-    ///         if (should_remove(*it))
-    ///             it = contacts.erase(it);
-    ///         else
-    ///             ++it;
-    ///     }
-    ///```
-    ///
-    /// Alternatively, you can use the first version with two loops: the first loop through all
-    /// contacts doesn't erase but just builds a vector of IDs to erase, then the second loops
-    /// through that vector calling `erase()` for each one.
+    /// It is NOT permitted to add/modify/remove records while iterating; instead such modifications
+    /// require two passes: an iterator loop to collect the required modifications, then a second
+    /// pass to apply the modifications.
     ///
     /// Declaration:
     /// ```cpp

--- a/include/session/config/convo_info_volatile.h
+++ b/include/session/config/convo_info_volatile.h
@@ -502,28 +502,8 @@ typedef struct convo_info_volatile_iterator convo_info_volatile_iterator;
 ///     convo_info_volatile_iterator_free(it);
 /// ```
 ///
-/// It is permitted to modify records (e.g. with a call to one of the `convo_info_volatile_set_*`
-/// functions) and add records while iterating.
-///
-/// If you need to remove while iterating then usage is slightly different: you must advance the
-/// iteration by calling either convo_info_volatile_iterator_advance if not deleting, or
-/// convo_info_volatile_iterator_erase to erase and advance.  Usage looks like this:
-/// ```cpp
-///     convo_info_volatile_1to1 c1;
-///     convo_info_volatile_iterator *it = convo_info_volatile_iterator_new(my_convos);
-///     while (!convo_info_volatile_iterator_done(it)) {
-///         if (convo_it_is_1to1(it, &c1)) {
-///             bool should_delete = /* ... */;
-///             if (should_delete)
-///                 convo_info_volatile_iterator_erase(it);
-///             else
-///                 convo_info_volatile_iterator_advance(it);
-///         } else {
-///             convo_info_volatile_iterator_advance(it);
-///         }
-///     }
-///     convo_info_volatile_iterator_free(it);
-/// ```
+/// It is NOT permitted to add/modify/remove records while iterating; instead you must use two
+/// loops: a first one to identify changes, and a second to apply them.
 ///
 /// Declaration:
 /// ```cpp
@@ -728,27 +708,6 @@ LIBSESSION_EXPORT bool convo_info_volatile_it_is_community(
 /// - `bool` -- True if the record is a legacy group conversation
 LIBSESSION_EXPORT bool convo_info_volatile_it_is_legacy_group(
         convo_info_volatile_iterator* it, convo_info_volatile_legacy_group* c);
-
-/// API: convo_info_volatile/convo_info_volatile_iterator_erase
-///
-/// Erases the current convo while advancing the iterator to the next convo in the iteration.
-///
-/// Declaration:
-/// ```cpp
-/// VOID convo_info_volatile_iterator_erase(
-///     [in]    config_object*                  conf,
-///     [in]    convo_info_volatile_iterator*   it
-/// );
-/// ```
-///
-/// Inputs:
-/// - `conf` -- [in] Pointer to the config object
-/// - `it` -- [in] The convo_info_volatile_iterator
-///
-/// Outputs:
-/// - `void` -- Nothing Returned
-LIBSESSION_EXPORT void convo_info_volatile_iterator_erase(
-        config_object* conf, convo_info_volatile_iterator* it);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/include/session/config/user_groups.h
+++ b/include/session/config/user_groups.h
@@ -613,28 +613,7 @@ typedef struct user_groups_iterator user_groups_iterator;
 ///     user_groups_iterator_free(it);
 /// ```
 ///
-/// It is permitted to modify records (e.g. with a call to one of the `user_groups_set_*`
-/// functions) and add records while iterating.
-///
-/// If you need to remove while iterating then usage is slightly different: you must advance the
-/// iteration by calling either user_groups_iterator_advance if not deleting, or
-/// user_groups_iterator_erase to erase and advance.  Usage looks like this:
-/// ```cpp
-///     ugroups_community_info comm;
-///     ugroups_iterator *it = ugroups_iterator_new(my_groups);
-///     while (!user_groups_iterator_done(it)) {
-///         if (user_groups_it_is_community(it, &comm)) {
-///             bool should_delete = /* ... */;
-///             if (should_delete)
-///                 user_groups_iterator_erase(it);
-///             else
-///                 user_groups_iterator_advance(it);
-///         } else {
-///             user_groups_iterator_advance(it);
-///         }
-///     }
-///     user_groups_iterator_free(it);
-/// ```
+/// It is NOT permitted to add/remove/modify records while iterating.
 ///
 /// Declaration:
 /// ```cpp
@@ -793,26 +772,6 @@ LIBSESSION_EXPORT bool user_groups_it_is_community(
 /// - `bool` -- Returns True if the group is a legacy group
 LIBSESSION_EXPORT bool user_groups_it_is_legacy_group(
         user_groups_iterator* it, ugroups_legacy_group_info* c);
-
-/// API: user_groups/user_groups_iterator_erase
-///
-/// Erases the current group while advancing the iterator to the next group in the iteration.
-///
-/// Declaration:
-/// ```cpp
-/// VOID user_groups_iterator_erase(
-///     [in]    config_object*              conf,
-///     [in]    user_groups_iterator*       it
-/// );
-/// ```
-///
-/// Inputs:
-/// - `conf` -- [in] Pointer to the config object
-/// - `it` -- [in] The user_groups_iterator
-///
-/// Outputs:
-/// - `void` -- Nothing Returned
-LIBSESSION_EXPORT void user_groups_iterator_erase(config_object* conf, user_groups_iterator* it);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/include/session/config/user_groups.hpp
+++ b/include/session/config/user_groups.hpp
@@ -469,27 +469,6 @@ class UserGroups : public ConfigBase {
     bool erase(const legacy_group_info& c);
     bool erase(const any_group_info& info);
 
-    struct iterator;
-
-    /// API: user_groups/UserGroups::erase(iterator)
-    ///
-    /// This works like erase, but takes an iterator to the contact to remove.  The element is
-    /// removed and the iterator to the next element after the removed one is returned.  This is
-    /// intended for use where elements are to be removed during iteration: see below for an
-    /// example.
-    ///
-    /// Declaration:
-    /// ```cpp
-    /// iterator erase(iterator it);
-    /// ```
-    ///
-    /// Inputs:
-    /// - `it` -- iterator resolving to the group to remove
-    ///
-    /// Outputs:
-    /// - `iterator` - Returns the next element after the removed one
-    iterator erase(iterator it);
-
     /// API: user_groups/UserGroups::size
     ///
     /// Returns the number of groups (of any type).
@@ -550,6 +529,7 @@ class UserGroups : public ConfigBase {
     /// - `bool` - Returns true if the contact list is empty
     bool empty() const { return size() == 0; }
 
+    struct iterator;
     /// API: user_groups/UserGroups::begin
     ///
     /// Iterators for iterating through all groups.  Typically you access this implicit via a
@@ -567,25 +547,9 @@ class UserGroups : public ConfigBase {
     /// This iterates through all groups in sorted order (sorted first by convo type, then by
     /// id within the type).
     ///
-    /// It is permitted to modify and add records while iterating (e.g. by modifying one of the
-    /// `comm`/`lg` objects and then calling set()).
-    ///
-    /// If you need to erase the current conversation during iteration then care is required: you
-    /// need to advance the iterator via the iterator version of erase when erasing an element
-    /// rather than incrementing it regularly.  For example:
-    /// ```cpp
-    ///     for (auto it = conversations.begin(); it != conversations.end(); ) {
-    ///         if (should_remove(*it))
-    ///             it = converations.erase(it);
-    ///         else
-    ///             ++it;
-    ///     }
-    /// ```
-    ///
-    /// Alternatively, you can use the first version with two loops: the first loop through all
-    /// converations doesn't erase but just builds a vector of IDs to erase, then the second loops
-    /// through that vector calling `erase_1to1()`/`erase_open()`/`erase_legacy_group()` for each
-    /// one.
+    /// It is NOT permitted to add/remove/modify records while iterating.  If such is needed it must
+    /// be done in two passes: once to collect the modifications, then a loop applying the collected
+    /// modifications.
     ///
     /// Declaration:
     /// ```cpp

--- a/src/config/contacts.cpp
+++ b/src/config/contacts.cpp
@@ -337,13 +337,6 @@ LIBSESSION_C_API bool contacts_erase(config_object* conf, const char* session_id
     }
 }
 
-Contacts::iterator Contacts::erase(iterator it) {
-    std::string session_id = it->session_id;
-    ++it;
-    erase(session_id);
-    return it;
-}
-
 size_t Contacts::size() const {
     if (auto* c = data["c"].dict())
         return c->size();
@@ -413,9 +406,4 @@ LIBSESSION_C_API bool contacts_iterator_done(contacts_iterator* it, contacts_con
 
 LIBSESSION_C_API void contacts_iterator_advance(contacts_iterator* it) {
     ++*static_cast<Contacts::iterator*>(it->_internals);
-}
-
-LIBSESSION_C_API void contacts_iterator_erase(config_object* conf, contacts_iterator* it) {
-    auto& real = *static_cast<Contacts::iterator*>(it->_internals);
-    real = unbox<Contacts>(conf)->erase(real);
 }

--- a/src/config/user_groups.cpp
+++ b/src/config/user_groups.cpp
@@ -351,12 +351,6 @@ bool UserGroups::erase_legacy_group(std::string_view id) {
     return erase(legacy_group_info{std::string{id}});
 }
 
-UserGroups::iterator UserGroups::erase(iterator it) {
-    auto remove_it = it++;
-    erase(*remove_it);
-    return it;
-}
-
 size_t UserGroups::size_communities() const {
     size_t count = 0;
     auto og = data["o"];
@@ -708,8 +702,4 @@ LIBSESSION_C_API bool user_groups_it_is_community(
 LIBSESSION_C_API bool user_groups_it_is_legacy_group(
         user_groups_iterator* it, ugroups_legacy_group_info* g) {
     return user_groups_it_is_impl<legacy_group_info>(it, g);
-}
-
-LIBSESSION_C_API void user_groups_iterator_erase(config_object* conf, user_groups_iterator* it) {
-    it->it = unbox<UserGroups>(conf)->erase(it->it);
 }

--- a/tests/test_config_contacts.cpp
+++ b/tests/test_config_contacts.cpp
@@ -356,15 +356,18 @@ TEST_CASE("Contacts (C API)", "[config][contacts][c]") {
     // Changing things while iterating:
     it = contacts_iterator_new(conf);
     int deletions = 0, non_deletions = 0;
+    std::vector<std::string> contacts_to_remove;
     while (!contacts_iterator_done(it, &ci)) {
         if (ci.session_id != std::string_view{definitely_real_id}) {
-            contacts_iterator_erase(conf, it);
+            contacts_to_remove.push_back(ci.session_id);
             deletions++;
         } else {
             non_deletions++;
-            contacts_iterator_advance(it);
         }
+        contacts_iterator_advance(it);
     }
+    for (auto& cont : contacts_to_remove)
+        contacts_erase(conf, cont.c_str());
 
     CHECK(deletions == 1);
     CHECK(non_deletions == 1);


### PR DESCRIPTION
Erasure can cause config dirtying, which invalidates not only all current iterators, but also the current dict object and isn't something we can realistically manage while iterating.

Currently, if this happened, we would crash, which is bad.

This removes the iterator-erase interface completely to avoid the issue, and updates documentation to state that modifications while iterating are *NOT* permitted.