### PR TITLE
fix: use npx to run docsify so that it finds the local install

### DIFF
--- a/docs/api/make-docs.sh
+++ b/docs/api/make-docs.sh
@@ -20,7 +20,7 @@ if [ -d "$destdir" ]; then
     rm -rf "$destdir"
 fi
 
-docsify init --local "$destdir"
+npx docsify init --local "$destdir"
 
 rm -Rf "$destdir"/vendor/themes
 rm -f "$destdir"/README.md


### PR DESCRIPTION
This should prevent any OS specific issues with NPM