### PR TITLE
Fix plaintext size calculation

### DIFF
--- a/src/config/groups/keys.cpp
+++ b/src/config/groups/keys.cpp
@@ -1212,7 +1212,9 @@ std::optional<ustring> Keys::decrypt_message(ustring_view ciphertext) const {
         case 'x': {
             auto nonce = ciphertext.substr(0, crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);
             ciphertext.remove_prefix(crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);
-            plain.resize(ciphertext.size() - OVERHEAD);
+            plain.resize(
+                    ciphertext.size() -
+                    (OVERHEAD - 1 - crypto_aead_xchacha20poly1305_ietf_NPUBBYTES));
             for (auto& k : keys_) {
                 if (0 == crypto_aead_xchacha20poly1305_ietf_decrypt(
                                  plain.data(),

--- a/tests/test_group_keys.cpp
+++ b/tests/test_group_keys.cpp
@@ -412,6 +412,18 @@ TEST_CASE("Group Keys - C++ API", "[config][groups][keys][cpp]") {
             CHECK(m.keys.current_hashes() == std::unordered_set{{"keyhash5"s}});
     }
 
+    auto decrypted1 = members.back().keys.decrypt_message(compressed);
+    REQUIRE(decrypted1);
+    CHECK(to_sv(*decrypted1) == msg);
+
+    auto decrypted2 = members.back().keys.decrypt_message(uncompressed);
+    REQUIRE(decrypted2);
+    CHECK(to_sv(*decrypted2) == msg);
+
+    auto bad_compressed = compressed;
+    bad_compressed.back() ^= 0b100;
+    CHECK_FALSE(members.back().keys.decrypt_message(bad_compressed));
+
     // Duplicate members[1] from dumps
     auto& m1b = members.emplace_back(
             member_seeds[1],


### PR DESCRIPTION
ciphertext has already been reduced by 1 +
crypto_aead_xchacha20poly1305_ietf_NPUBBYTES at this point, but that wasn't being accounted for in the size calculations.

(Thanks to @ftrget for finding this one!)