### PR TITLE
Fix issue with decryption of a still-pending key

### DIFF
--- a/tests/test_group_keys.cpp
+++ b/tests/test_group_keys.cpp
@@ -475,6 +475,10 @@ TEST_CASE("Group Keys - C++ API", "[config][groups][keys][cpp]") {
     }
 
     ustring new_keys_config7{admin1.keys.rekey(admin1.info, admin1.members)};
+
+    // Make sure we can encrypt & decrypt even if the rekey is still pending:
+    CHECK(admin1.keys.decrypt_message(admin1.keys.encrypt_message(to_usv("abc"))));
+
     auto [iseq7, ipush7, iobs7] = admin1.info.push();
     info_configs.emplace_back("ifakehash7", ipush7);
     admin1.info.confirm_pushed(iseq7, "ifakehash7");


### PR DESCRIPTION
If you call rekey() and then encrypt_message() before the rekey is confirmed, decryption would fail because the pending key wouldn't be tried yet.  This fixes it (including a verified-to-have-failed test case).

Thanks to Harris for the help tracking down/debugging this one.