### PR TITLE
Better targets for use as a submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,10 @@ if (BUILD_STATIC_DEPS)
     include(StaticBuild)
 endif()
 
+# Add a "libsession::libsession" target that depends on everything; when building a general purpose
+# program that links against libsession, this is generally what you want to depend on.
+add_library(libsession INTERFACE)
+
 if(STATIC_BUNDLE)
 
     include(combine_archives)
@@ -133,7 +137,23 @@ if(STATIC_BUNDLE)
 
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libsession-util.a
         ARCHIVE DESTINATION ${lib_folder})
+
+    # Add a target for the bundled library output:
+    add_library(libsession::util ALIAS session-util)
+
+    target_link_libraries(libsession INTERFACE libsession::util)
+else()
+    foreach(tgt ${libsession_export_targets})
+        target_link_libraries(libsession INTERFACE libsession::${tgt})
+    endforeach()
 endif()
+
+add_library(libsession::libsession ALIAS libsession)
+export(
+    TARGETS libsession
+    NAMESPACE libsession::
+    APPEND FILE libsessionTargets.cmake
+)
 
 
 option(WITH_TESTS "Enable unit tests" ${libsession_IS_TOPLEVEL_PROJECT})

--- a/cmake/combine_archives.cmake
+++ b/cmake/combine_archives.cmake
@@ -24,5 +24,11 @@ function(combine_archives output_archive dep_target)
         DEPENDS ${mri_file} ${ARGN}
         COMMAND /usr/bin/libtool -static -o ${FULL_OUTPUT_PATH} ${merge_libs})
   endif()
-  add_custom_target(${output_archive} DEPENDS ${FULL_OUTPUT_PATH})
+  add_custom_target(${output_archive}-lib DEPENDS ${FULL_OUTPUT_PATH})
+  add_library(${output_archive} STATIC IMPORTED GLOBAL)
+  set_target_properties(${output_archive} PROPERTIES
+      IMPORTED_LOCATION ${FULL_OUTPUT_PATH}
+      IMPORTED_LINK_INTERFACE_LANGUAGES "C;CXX"
+  )
+  add_dependencies(${output_archive} ${output_archive}-lib)
 endfunction(combine_archives)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -137,7 +137,7 @@ endforeach()
 export(
     TARGETS ${export_targets} common version
     NAMESPACE libsession::
-    FILE libsessionTargets.cmake
+    FILE ../libsessionTargets.cmake
 )
 
 set(libsession_export_targets "${export_targets}" PARENT_SCOPE)


### PR DESCRIPTION
Add a `libsession::libsession` target that is a "everything" target.

Add a `libsession::util` target when using STATIC_BUNDLE that depends on the combined bundled file.