### PR TITLE
Fixed an issue where the auth_data wasn't getting cleared correctly

### DIFF
--- a/src/config/user_groups.cpp
+++ b/src/config/user_groups.cpp
@@ -432,6 +432,8 @@ void UserGroups::set(const group_info& g) {
         info["K"] = ustring_view{};
         if (g.auth_data.size() == 100)
             info["s"] = g.auth_data;
+        else
+            info["s"] = ustring_view{};
     }
 }
 

--- a/src/config/user_groups.cpp
+++ b/src/config/user_groups.cpp
@@ -433,7 +433,7 @@ void UserGroups::set(const group_info& g) {
         if (g.auth_data.size() == 100)
             info["s"] = g.auth_data;
         else
-            info["s"] = ustring_view{};
+            info["s"].erase();
     }
 }
 


### PR DESCRIPTION
When calling `ugroups_group_set_kicked()` followed by `user_groups_set_group()` in the C API the `auth_data` wasn't getting cleared.