### PR TITLE
Switch to oxen-encoding's signature helpers

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -103,7 +103,7 @@ if(CMAKE_CROSSCOMPILING)
 endif()
 
 
-system_or_submodule(OXENC oxenc liboxenc>=1.0.8 oxen-encoding)
+system_or_submodule(OXENC oxenc liboxenc>=1.0.10 oxen-encoding)
 
 
 if(CMAKE_C_COMPILER_LAUNCHER)

--- a/include/session/config.hpp
+++ b/include/session/config.hpp
@@ -371,9 +371,10 @@ class MutableConfigMessage : public ConfigMessage {
 /// - `verified_signature` is a pointer to a std::optional array of signature data; if this is
 ///   specified and not nullptr then the optional with be emplaced with the signature bytes if the
 ///   signature successfully validates.
-/// - `trust_signature` bypasses the verification and signature requirements, blinding trusting a
-///   signature if present.  This is intended for use when restoring from a dump (along with a
-///   nullptr verifier).
+/// - `trust_signature` allows setting `verified_signature` when a signature is present but no
+///   verifier is provided to verify it.  Without specifying this, `verified_signature` will only be
+///   set when the signature actually validates via a `verifier` call.  This is primarily used
+///   during restoring config dumps.
 ///
 /// Outputs:
 /// - returns with no value on success

--- a/include/session/config/groups/keys.hpp
+++ b/include/session/config/groups/keys.hpp
@@ -109,6 +109,8 @@ class Keys final : public ConfigSig {
     void set_verifier(ConfigMessage::verify_callable v) override { verifier_ = std::move(v); }
     void set_signer(ConfigMessage::sign_callable s) override { signer_ = std::move(s); }
 
+    ustring sign(ustring_view data) const;
+
     // Checks for and drops expired keys.
     void remove_expired();
 


### PR DESCRIPTION
This removes some fragile (though working) bt-dict signature code with equivalent code now in oxen-encoding.