### PR TITLE
Added the `removed_status` value and a way to retrieve the current `GROUP_KEYS` generation

### DIFF
--- a/include/session/config/groups/keys.h
+++ b/include/session/config/groups/keys.h
@@ -301,8 +301,7 @@ LIBSESSION_EXPORT bool groups_keys_key_supplement(
 ///
 /// Oututs:
 /// - `int` -- latest keys generation number on success; returns `-1` on failure.
-LIBSESSION_EXPORT int groups_keys_current_generation(
-        config_group_keys* conf);
+LIBSESSION_EXPORT int groups_keys_current_generation(config_group_keys* conf);
 
 /// API: groups/groups_keys_swarm_make_subaccount
 ///

--- a/include/session/config/groups/keys.h
+++ b/include/session/config/groups/keys.h
@@ -292,6 +292,18 @@ LIBSESSION_EXPORT bool groups_keys_key_supplement(
         unsigned char** message,
         size_t* message_len);
 
+/// API: groups/groups_keys_current_generation
+///
+/// Returns the current generation number for the latest keys message.
+///
+/// Inputs:
+/// - `conf` -- [in] Pointer to the config object
+///
+/// Oututs:
+/// - `int` -- latest keys generation number on success; returns `-1` on failure.
+LIBSESSION_EXPORT int groups_keys_current_generation(
+        config_group_keys* conf);
+
 /// API: groups/groups_keys_swarm_make_subaccount
 ///
 /// Constructs a swarm subaccount signing value that a member can use to access messages in the

--- a/include/session/config/groups/keys.h
+++ b/include/session/config/groups/keys.h
@@ -300,7 +300,7 @@ LIBSESSION_EXPORT bool groups_keys_key_supplement(
 /// - `conf` -- [in] Pointer to the config object
 ///
 /// Oututs:
-/// - `int` -- latest keys generation number on success; returns `-1` on failure.
+/// - `int` -- latest keys generation number
 LIBSESSION_EXPORT int groups_keys_current_generation(config_group_keys* conf);
 
 /// API: groups/groups_keys_swarm_make_subaccount

--- a/include/session/config/groups/keys.hpp
+++ b/include/session/config/groups/keys.hpp
@@ -320,6 +320,14 @@ class Keys final : public ConfigSig {
         return key_supplement(std::vector{{std::move(sid)}});
     }
 
+    /// API: groups/current_generation
+    ///
+    /// Returns the current generation number for the latest keys message.
+    ///
+    /// Oututs:
+    /// - `int` -- latest keys generation number.
+    int current_generation() const { return keys_.empty() ? 0 : keys_.back().generation; }
+
     /// API: groups/Keys::swarm_make_subaccount
     ///
     /// Constructs a swarm subaccount signing value that a member can use to access messages in the

--- a/include/session/config/groups/members.h
+++ b/include/session/config/groups/members.h
@@ -9,6 +9,7 @@ extern "C" {
 #include "../util.h"
 
 enum groups_members_invite_status { INVITE_SENT = 1, INVITE_FAILED = 2 };
+enum groups_members_remove_status { REMOVED_MEMBER = 1, REMOVED_MEMBER_AND_MESSAGES = 2 };
 
 typedef struct config_group_member {
     char session_id[67];  // in hex; 66 hex chars + null terminator.
@@ -20,6 +21,7 @@ typedef struct config_group_member {
     bool admin;
     int invited;   // 0 == unset, INVITE_SENT = invited, INVITED_FAILED = invite failed to send
     int promoted;  // same value as `invited`, but for promotion-to-admin
+    int removed;   // 0 == unset, REMOVED_MEMBER = removed, REMOVED_MEMBER_AND_MESSAGES = remove member and their messages
     bool supplement;
 
 } config_group_member;

--- a/include/session/config/groups/members.h
+++ b/include/session/config/groups/members.h
@@ -21,7 +21,8 @@ typedef struct config_group_member {
     bool admin;
     int invited;   // 0 == unset, INVITE_SENT = invited, INVITED_FAILED = invite failed to send
     int promoted;  // same value as `invited`, but for promotion-to-admin
-    int removed;   // 0 == unset, REMOVED_MEMBER = removed, REMOVED_MEMBER_AND_MESSAGES = remove member and their messages
+    int removed;   // 0 == unset, REMOVED_MEMBER = removed, REMOVED_MEMBER_AND_MESSAGES = remove
+                   // member and their messages
     bool supplement;
 
 } config_group_member;

--- a/include/session/config/groups/members.hpp
+++ b/include/session/config/groups/members.hpp
@@ -40,6 +40,7 @@ using namespace std::literals;
 ///       - omitted once the promotion is accepted (i.e. once `A` gets set).
 
 constexpr int INVITE_SENT = 1, INVITE_FAILED = 2;
+constexpr int REMOVED_MEMBER = 1, REMOVED_MEMBER_AND_MESSAGES = 2;
 
 /// Struct containing member details
 struct member {
@@ -199,6 +200,45 @@ struct member {
     /// Outputs:
     /// - `bool` -- true if the member is promoted (or promotion-in-progress)
     bool promoted() const { return admin || promotion_pending(); }
+
+    // Flags to track a removed user.  This value is typically not used directly, but
+    // rather via the `set_removed()`, `is_removed()` and similar methods.
+    int removed_status = 0;
+
+    /// API: groups/member::set_removed
+    ///
+    /// Sets the "removed" flag for this user.  This marks the user as pending removal from the
+    /// group.  The optional `messages` parameter can be specified as true if we want to remove
+    /// any messages sent by the member upon a successful removal.
+    ///
+    /// Inputs:
+    /// - `messages`: can be specified as true to indicate any messages sent by the member
+    ///   should also be removed upon a successful member removal.
+    void set_removed(bool messages = false) {
+        removed_status = messages ? REMOVED_MEMBER_AND_MESSAGES : REMOVED_MEMBER;
+    }
+
+    /// API: groups/member::is_removed
+    ///
+    /// Returns true if the user should be removed from the group.
+    ///
+    /// Inputs: none.
+    ///
+    /// Outputs:
+    /// - `bool` -- true if the member should be removed from the group
+    bool is_removed() const { return removed_status > 0; }
+
+    /// API: groups/member::should_remove_messages
+    ///
+    /// Returns true if the users messages should be removed after they are
+    /// successfully removed.
+    ///
+    /// Inputs: none.
+    ///
+    /// Outputs:
+    /// - `bool` -- true if the members messages should be removed after they are
+    /// successfully removed from the group
+    bool should_remove_messages() const { return removed_status == REMOVED_MEMBER_AND_MESSAGES; }
 
     /// API: groups/member::into
     ///

--- a/src/config/groups/keys.cpp
+++ b/src/config/groups/keys.cpp
@@ -1574,6 +1574,16 @@ LIBSESSION_C_API bool groups_keys_key_supplement(
     }
 }
 
+LIBSESSION_EXPORT int groups_keys_current_generation(
+        config_group_keys* conf) {
+    try {
+        return unbox(conf).current_generation();
+    } catch (const std::exception& e) {
+        set_error(conf, e.what());
+        return -1;
+    }
+}
+
 LIBSESSION_C_API bool groups_keys_swarm_make_subaccount_flags(
         config_group_keys* conf,
         const char* session_id,

--- a/src/config/groups/keys.cpp
+++ b/src/config/groups/keys.cpp
@@ -1574,8 +1574,7 @@ LIBSESSION_C_API bool groups_keys_key_supplement(
     }
 }
 
-LIBSESSION_EXPORT int groups_keys_current_generation(
-        config_group_keys* conf) {
+LIBSESSION_EXPORT int groups_keys_current_generation(config_group_keys* conf) {
     try {
         return unbox(conf).current_generation();
     } catch (const std::exception& e) {

--- a/src/config/groups/keys.cpp
+++ b/src/config/groups/keys.cpp
@@ -1575,12 +1575,7 @@ LIBSESSION_C_API bool groups_keys_key_supplement(
 }
 
 LIBSESSION_EXPORT int groups_keys_current_generation(config_group_keys* conf) {
-    try {
-        return unbox(conf).current_generation();
-    } catch (const std::exception& e) {
-        set_error(conf, e.what());
-        return -1;
-    }
+    return unbox(conf).current_generation();
 }
 
 LIBSESSION_C_API bool groups_keys_swarm_make_subaccount_flags(

--- a/src/config/groups/members.cpp
+++ b/src/config/groups/members.cpp
@@ -143,7 +143,9 @@ member::member(const config_group_member& m) : session_id{m.session_id, 66} {
     admin = m.admin;
     invite_status = (m.invited == INVITE_SENT || m.invited == INVITE_FAILED) ? m.invited : 0;
     promotion_status = (m.promoted == INVITE_SENT || m.promoted == INVITE_FAILED) ? m.promoted : 0;
-    removed_status = (m.removed == REMOVED_MEMBER || m.removed == REMOVED_MEMBER_AND_MESSAGES) ? m.removed : 0;
+    removed_status = (m.removed == REMOVED_MEMBER || m.removed == REMOVED_MEMBER_AND_MESSAGES)
+                           ? m.removed
+                           : 0;
     supplement = m.supplement;
 }
 

--- a/src/config/groups/members.cpp
+++ b/src/config/groups/members.cpp
@@ -52,6 +52,7 @@ void Members::set(const member& mem) {
     set_positive_int(info["P"], mem.admin ? 0 : mem.promotion_status);
     set_positive_int(info["I"], mem.admin ? 0 : mem.invite_status);
     set_flag(info["s"], mem.supplement);
+    set_flag(info["R"], mem.removed_status);
 }
 
 void member::load(const dict& info_dict) {
@@ -69,6 +70,7 @@ void member::load(const dict& info_dict) {
     admin = maybe_int(info_dict, "A").value_or(0);
     invite_status = admin ? 0 : maybe_int(info_dict, "I").value_or(0);
     promotion_status = admin ? 0 : maybe_int(info_dict, "P").value_or(0);
+    removed_status = maybe_int(info_dict, "R").value_or(0);
     supplement = invite_pending() && !promoted() ? maybe_int(info_dict, "s").value_or(0) : 0;
 }
 
@@ -141,6 +143,7 @@ member::member(const config_group_member& m) : session_id{m.session_id, 66} {
     admin = m.admin;
     invite_status = (m.invited == INVITE_SENT || m.invited == INVITE_FAILED) ? m.invited : 0;
     promotion_status = (m.promoted == INVITE_SENT || m.promoted == INVITE_FAILED) ? m.promoted : 0;
+    removed_status = (m.removed == REMOVED_MEMBER || m.removed == REMOVED_MEMBER_AND_MESSAGES) ? m.removed : 0;
     supplement = m.supplement;
 }
 
@@ -158,6 +161,7 @@ void member::into(config_group_member& m) const {
     static_assert(groups::INVITE_FAILED == ::INVITE_FAILED);
     m.invited = invite_status;
     m.promoted = promotion_status;
+    m.removed = removed_status;
     m.supplement = supplement;
 }
 

--- a/src/config/groups/members.cpp
+++ b/src/config/groups/members.cpp
@@ -52,7 +52,7 @@ void Members::set(const member& mem) {
     set_positive_int(info["P"], mem.admin ? 0 : mem.promotion_status);
     set_positive_int(info["I"], mem.admin ? 0 : mem.invite_status);
     set_flag(info["s"], mem.supplement);
-    set_flag(info["R"], mem.removed_status);
+    set_positive_int(info["R"], mem.removed_status);
 }
 
 void member::load(const dict& info_dict) {

--- a/tests/test_group_members.cpp
+++ b/tests/test_group_members.cpp
@@ -119,6 +119,8 @@ TEST_CASE("Group Members", "[config][groups][members]") {
             CHECK_FALSE(m.invite_failed());
             CHECK_FALSE(m.promotion_pending());
             CHECK_FALSE(m.promotion_failed());
+            CHECK_FALSE(m.is_removed());
+            CHECK_FALSE(m.should_remove_messages());
             CHECK_FALSE(m.supplement);
             if (i < 10) {
                 CHECK(m.admin);
@@ -165,6 +167,11 @@ TEST_CASE("Group Members", "[config][groups][members]") {
         m.set_promoted(i >= 60);
         gmem2.set(m);
     }
+    for (int i = 62; i < 66; i++) {
+        auto m = gmem2.get_or_construct(sids[i]);
+        m.set_removed(i >= 64);
+        gmem2.set(m);
+    }
 
     CHECK(gmem2.get(sids[23]).value().name == "Member 23");
 
@@ -196,6 +203,8 @@ TEST_CASE("Group Members", "[config][groups][members]") {
             CHECK(m.promoted() == (i < 10 || (i >= 58 && i < 62)));
             CHECK(m.promotion_pending() == (i >= 58 && i < 62));
             CHECK(m.promotion_failed() == (i >= 60 && i < 62));
+            CHECK(m.is_removed() == (i >= 62 && i < 66));
+            CHECK(m.should_remove_messages() == (i >= 64 && i < 66));
             i++;
         }
         CHECK(i == 62);
@@ -247,10 +256,12 @@ TEST_CASE("Group Members", "[config][groups][members]") {
             CHECK(m.promoted() == (i < 10 || (i >= 58 && i < 62)));
             CHECK(m.promotion_pending() == (i >= 59 && i <= 61));
             CHECK(m.promotion_failed() == (i >= 60 && i <= 61));
+            CHECK(m.is_removed() == (i >= 62 && i < 66));
+            CHECK(m.should_remove_messages() == (i >= 64 && i < 66));
             do
                 i++;
             while (is_prime100(i));
         }
-        CHECK(i == 62);
+        CHECK(i == 66);
     }
 }

--- a/tests/test_group_members.cpp
+++ b/tests/test_group_members.cpp
@@ -207,7 +207,7 @@ TEST_CASE("Group Members", "[config][groups][members]") {
             CHECK(m.should_remove_messages() == (i >= 64 && i < 66));
             i++;
         }
-        CHECK(i == 62);
+        CHECK(i == 66);
     }
 
     for (int i = 0; i < 100; i++) {


### PR DESCRIPTION
Added a new removed value to enable admins to better recover from failing to properly remove members from a group, the value indicates whether just the member should be removed or if their messages should also be removed alongside them

Also added a `current_generation` function which retrieves the current `GROUP_KEYS` generation value