### PR TITLE
Add group keys function for key promotion

### DIFF
--- a/include/session/config/groups/keys.h
+++ b/include/session/config/groups/keys.h
@@ -120,6 +120,29 @@ LIBSESSION_EXPORT const unsigned char* groups_keys_get_key(const config_group_ke
 /// - `true` if we have admin keys, `false` otherwise.
 LIBSESSION_EXPORT bool groups_keys_is_admin(const config_group_keys* conf);
 
+/// API: groups/groups_keys_load_admin_key
+///
+/// Loads the admin keys, effectively upgrading this keys object from a member to an admin.
+///
+/// This does nothing if the keys object already has admin keys.
+///
+/// Inputs:
+/// - `conf` -- the groups keys config object
+/// - `secret` -- pointer to the 32-byte group seed.  (This a 64-byte libsodium "secret key" begins
+///   with the seed, this can also be a given a pointer to such a value).
+/// - `group_info_conf` -- the group info config instance (the key will be added)
+/// - `group_members_conf` -- the group members config instance (the key will be added)
+///
+/// Outputs:
+/// - `true` if the object has been upgraded to admin status, or was already admin status; `false`
+///   if the given seed value does not match the group's public key.  If this returns `true` then
+///   after the call a call to `groups_keys_is_admin` would also return `true`.
+LIBSESSION_EXPORT bool groups_keys_load_admin_key(
+        config_group_keys* conf,
+        const unsigned char* secret,
+        config_object* group_info_conf,
+        config_object* group_members_conf);
+
 /// API: groups/groups_keys_rekey
 ///
 /// Generates a new encryption key for the group and returns an encrypted key message to be pushed

--- a/include/session/config/groups/keys.hpp
+++ b/include/session/config/groups/keys.hpp
@@ -258,6 +258,29 @@ class Keys final : public ConfigSig {
     /// - `true` if this object knows the group's master key
     bool admin() const { return _sign_sk && _sign_pk; }
 
+    /// API: groups/Keys::load_admin_key
+    ///
+    /// Loads the group secret key into the Keys object (as well as passing it along to the Info and
+    /// Members objects).
+    ///
+    /// The primary use of this is when accepting a promotion-to-admin: the Keys object would be
+    /// constructed as a regular member (without the admin key) then this method "upgrades" the
+    /// object with the group signing key.
+    ///
+    /// This will do nothing if the secret key is already known; it will throw if
+    /// the given secret key does not yield the group's public key.  The given key can be either the
+    /// 32 byte seed, or the libsodium 64 byte "secret key" (which is just the seed and cached
+    /// public key stuck together).
+    ///
+    /// Inputs:
+    /// - `secret` -- the group's 64-byte secret key or 32-byte seed
+    /// - `info` and `members` -- will be loaded with the group keys if the key is loaded
+    ///   successfully.
+    ///
+    /// Outputs: nothing.  After a successful call, `admin()` will return true.  Throws if the given
+    /// secret key does not match the group's pubkey.
+    void load_admin_key(ustring_view secret, Info& info, Members& members);
+
     /// API: groups/Keys::rekey
     ///
     /// Generate a new encryption key for the group and returns an encrypted key message to be


### PR DESCRIPTION
There was no nice way to "promote" a set of group objects from member status to admin status by giving them the key.  This adds Keys::load_admin_key to do just that.