### PR TITLE
Add Multi-encrypt functions

### DIFF
--- a/include/session/multi_encrypt.h
+++ b/include/session/multi_encrypt.h
@@ -1,0 +1,140 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stddef.h>
+
+#include "export.h"
+
+/// API: crypto/session_encrypt_for_multiple_simple
+///
+/// This function performs 1-to-N or N-to-N encryptions (i.e. N encrypted payloads of either the
+/// same value, or N separate values) using a random nonce and encodes the resulting encrypted data
+/// in a self-contained bt-encoded value suitable for decrypting by a recipient via
+/// `session_decrypt_for_multiple_simple`.
+///
+/// Inputs:
+/// - `out_len` -- pointer to a size_t where the length of the returned buffer will be written.
+/// - `messages` -- array of pointers to messages to encrypt.  This vector can either be a single
+/// message to
+///   separately encrypt the same message for each member, or a vector of the same length as
+///   recipients to encrypt a different message for each member.
+/// - `messages_lengths` -- array of the length of the buffers in `messages`.  Must be the same
+///   length as `messages`.
+/// - `n_messages` -- the number of messages provided.
+/// - `recipients` -- array of pointers to recipient X25519 pubkeys.  Each pubkey is 32 bytes.
+///   These are typically binary Session IDs, not including the 0x05 prefix.
+/// - `n_recipients` -- the length of `recipients`
+/// - `x25519_privkey` -- the X25519 private key of the sender (32 bytes).  Note that this is *NOT*
+///   the Ed25519 secret key; see the alternative version of the function below if you only have an
+///   Ed25519 key.
+/// - `x25519_pubkey` -- the X25519 public key of the sender (32 bytes).  This needs to be known by
+///   the recipient in order to decrypt the message; unlike session-protocol encryption, the sender
+///   identity is not included in the message.
+/// - `domain` -- a regular C string that uniquely identifies the "domain" of encryption, such as
+///   "SessionGroupKickedMessage".  The value is arbitrary: what matters is that it is unique for
+///   different encryption types, and that both the sender and recipient use the same value.  Max
+///   length is 64 bytes.  Using a domain is encouraged so that the resulting encryption key between
+///   a sender and recipient will be different if the same keys are used for encryption of unrelated
+///   data types.
+/// - `nonce` -- optional nonce.  Typically you should pass `NULL` here, which will cause a random
+///   nonce to be used, but a 24-byte nonce can be specified for deterministic encryption.  (Note
+///   that steps should be taken to ensure the nonce is not reused if specifying a nonce).
+/// - `pad` -- if set to a value greater than 1 then junk encrypted values will be added until there
+///   are a multiple of this many encrypted values in total.  The size of each junk entry will be
+///   the same as the (encrypted) size of the first message; this padding is most useful when all
+///   messages are the same size (or the same message) as with variable-sized messages the junk
+///   entries will be somewhat identifiable.  Set to 0 to disable junk entry padding.
+///
+/// Outputs:
+/// malloced buffer containing the encoded data, or NULL if encryption failed.  It is the caller's
+/// responsibility to `free()` this buffer (if non-NULL) when done with it!
+LIBSESSION_EXPORT unsigned char* session_encrypt_for_multiple_simple(
+        size_t* out_len,
+        const unsigned char** messages,
+        const size_t* message_lengths,
+        size_t n_messages,
+        const unsigned char** recipients,
+        size_t n_recipients,
+        const unsigned char* x25519_privkey,
+        const unsigned char* x25519_pubkey,
+        const char* domain,
+        const unsigned char* nonce,
+        int pad);
+
+/// This does the same as the above, except that it takes a single, 64-byte libsodium-style Ed25519
+/// secret key instead of the x25519 privkey/pubkey argument pair.  The X25519 keys are converted
+/// from the Ed25519 key on the fly.
+LIBSESSION_EXPORT unsigned char* session_encrypt_for_multiple_simple_ed25519(
+        size_t* out_len,
+        const unsigned char** messages,
+        const size_t* message_lengths,
+        size_t n_messages,
+        const unsigned char** recipients,
+        size_t n_recipients,
+        const unsigned char* ed25519_secret_key,
+        const char* domain,
+        const unsigned char* nonce,
+        int pad);
+
+/// API: crypto/session_decrypt_for_multiple_simple
+///
+/// This function attempts to decrypt a message produced by `session_encrypt_for_multiple_simple`;
+/// if encryption (of any of the contained messages) succeeds you get back the message, otherwise if
+/// the message failed to parse or decryption of all parts fails, you get back NULL.
+///
+/// Inputs:
+/// - `out_len` -- pointer to a size_t where the length of the decrypted value will be written *if*
+///   decryption succeeds.
+/// - `encoded` -- the incoming message, produced by session_encrypt_for_multiple_simple
+/// - `encoded_len` -- size of `encoded`
+/// - `x25519_privkey` -- the X25519 private key of the receiver (32 bytes).  Note that this is
+///   *NOT* the Ed25519 secret key; see the alternative version of the function below if you only
+///   have an Ed25519 key.
+/// - `x25519_pubkey` -- the X25519 public key of the receiver (32 bytes).
+/// - `sender_x25519_pubkey` -- the X25519 public key of the sender (32 bytes).  Note that unlike
+///   session encryption, the sender's identify is not available in the encrypted message itself.
+/// - `domain` -- the encryption domain, which must be the same as the value used in
+///   `session_encrypt_for_multiple_simple`.
+///
+/// Outputs:
+/// If decryption succeeds, returns a pointer to a malloc'ed buffer containing the decrypted message
+/// data, with length stored in `out_len`.  If parsing or decryption fails, returns NULL.  If the
+/// return is non-NULL it is the responsibility of the caller to free the returned pointer!
+LIBSESSION_EXPORT unsigned char* session_decrypt_for_multiple_simple(
+        size_t* out_len,
+        const unsigned char* encoded,
+        size_t encoded_len,
+        const unsigned char* x25519_privkey,
+        const unsigned char* x25519_pubkey,
+        const unsigned char* sender_x25519_pubkey,
+        const char* domain);
+
+/// Same as above, but takes the recipients privkey/pubkey as a single Ed25519 secret key (64 bytes)
+/// instead of a pair of X25519 argumensts.  The sender pubkey is still specified as an X25519
+/// pubkey.
+LIBSESSION_EXPORT unsigned char* session_decrypt_for_multiple_simple_ed25519_from_x25519(
+        size_t* out_len,
+        const unsigned char* encoded,
+        size_t encoded_len,
+        const unsigned char* ed25519_secret,
+        const unsigned char* sender_x25519_pubkey,
+        const char* domain);
+
+/// Same as above, but takes the recipients privkey/pubkey as a single Ed25519 secret key (64 bytes)
+/// instead of a pair of X25519 argumensts, *and* takes the sender's pubkey as an Ed25519 public
+/// key.  This is the typically the version you want when the "sender" is a group or other
+/// non-Session ID known by an Ed25519 pubkey (03... or other non-05 keys) rather than a Session ID.
+LIBSESSION_EXPORT unsigned char* session_decrypt_for_multiple_simple_ed25519(
+        size_t* out_len,
+        const unsigned char* encoded,
+        size_t encoded_len,
+        const unsigned char* ed25519_secret,
+        const unsigned char* sender_ed25519_pubkey,
+        const char* domain);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/session/multi_encrypt.hpp
+++ b/include/session/multi_encrypt.hpp
@@ -1,0 +1,252 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <exception>
+#include <optional>
+#include <stdexcept>
+#include <type_traits>
+#include <vector>
+
+#include "types.hpp"
+#include "util.hpp"
+
+// Helper functions for implementing multiply encrypted messages by creating separate copies of the
+// message for each message recipient.  This is used most prominently in group key update messages
+// to send a copy of the symmetric encryption key to each of a set of recipients.
+//
+// Details:
+// - we use xchacha20-poly1305 encryption
+// - we use a single nonce for all the encryptions (rather than a separate one for each encrypted
+//   copy).  Since we are use separate keys for each encryption, nonce reuse is not a concern.
+// - we support padding with optional junk entries
+// - we do not sign or identify the creator of the encrypted values here (i.e. it's the caller's
+//   responsibility to do that, if needed).
+// - the encryption key for sender a/A, recipient b/B is: H(aB || A || B) = H(bA || A || B), and so
+//   the recipient needs to know the sender's pubkey to decrypt the message.
+// - the general idea is for a potential recipient to brute-force attempt to decrypt all the
+//   messages to see if any work.
+// - this approach is really only meant for limited size groups and is not intended for large scale.
+
+namespace session {
+
+namespace detail {
+
+    void encrypt_multi_key(
+            std::array<unsigned char, 32>& key_out,
+            const unsigned char* a,
+            const unsigned char* A,
+            const unsigned char* B,
+            bool encrypting,
+            std::string_view domain);
+
+    void encrypt_multi_impl(
+            ustring& out,
+            ustring_view message,
+            const unsigned char* key,
+            const unsigned char* nonce);
+
+    bool decrypt_multi_impl(
+            ustring& out,
+            ustring_view ciphertext,
+            const unsigned char* key,
+            const unsigned char* nonce);
+
+    inline void validate_multi_fields(
+            ustring_view nonce, ustring_view privkey, ustring_view pubkey) {
+        if (nonce.size() < 24)
+            throw std::logic_error{"nonce must be 24 bytes"};
+        if (privkey.size() != 32)
+            throw std::logic_error{"privkey must be 32 bytes"};
+        if (pubkey.size() != 32)
+            throw std::logic_error{"pubkey requires a 32-byte pubkey"};
+    }
+
+}  // namespace detail
+
+/// API: crypto/encrypt_multiple_message_overhead
+///
+/// The number of bytes of overhead required per encrypted copy of the message as produced by
+/// `encrypt_for_multiple`.  This does not include the nonce or other data (such as the sender)
+/// that likely needs to be transmitted as well.
+extern const size_t encrypt_multiple_message_overhead;
+
+/// API: crypto/encrypt_for_multiple
+///
+/// Encrypts a message multiple times for multiple recipients.  `callable` is invoked once per
+/// encrypted (or junk) value, passed as a `ustring_view`.
+///
+/// Inputs:
+/// - `messages` -- a vector of message bodies to encrypt.  Must be either size 1, or of the same
+///   size as recipients.  If given a single message then that message is re-encrypted for each
+///   recipient; if given multiple messages then the nth message is encrypted for the nth recipient.
+///   See also session/util.hpp for a convenience function for converting other containers of
+///   string-like values to this view vector type.
+/// - `nonce` -- must be 24 bytes (can be longer, but only the first 24 will be used).  Should be
+///   secure random, or a cryptographically secure hash incorporating secret data.  The nonce should
+///   not be reused (if the same sender/recipient encryption/decryption key.
+/// - `privkey` -- the sender's X25519 private key.  Must be 32 bytes.  *NOT* an Ed25519 secret key:
+///   if that's what you have, you need to convert the privkey to X25519 first.
+/// - `pubkey` -- the sender's X25519 public key.  Can be empty to compute it from `privkey`.
+/// - `recipients` -- vector of recipient X25519 public keys.  Must be 32 bytes each (remove the 05
+///   if a session id).  *NOT* Ed25519 pubkeys; conversion to X25519 may be required if that's what
+///   you have.
+/// - `domain` -- some unique fixed string known to both sides; this is used in the hashing function
+///   used to generate individual keys for domain separation, and so should ideally have a different
+///   value in different contexts (i.e. group keys uses one value, kicked messages use another,
+///   etc.).  *Can* be empty, but should be set to something.
+/// - `call` -- this is invoked for each different encrypted value with a ustring_view; the caller
+///   must copy as needed as the ustring_view doesn't remain valid past the call.
+/// - `ignore_invalid_recipient` -- if given and true then any recipients that appear to have
+///   invalid public keys (i.e. the shared key multiplication fails) will be silently ignored (the
+///   callback will not be called).  If not given (or false) then such a failure for any recipient
+///   will raise an exception.
+template <typename F>
+void encrypt_for_multiple(
+        const std::vector<ustring_view> messages,
+        const std::vector<ustring_view> recipients,
+        ustring_view nonce,
+        ustring_view privkey,
+        ustring_view pubkey,
+        std::string_view domain,
+        F&& call,
+        bool ignore_invalid_recipient = false) {
+
+    detail::validate_multi_fields(nonce, privkey, pubkey);
+
+    for (const auto& r : recipients)
+        if (r.size() != 32)
+            throw std::logic_error{"encrypt_for_multiple requires 32-byte recipients pubkeys"};
+    if (messages.size() != 1 && messages.size() != recipients.size())
+        throw std::logic_error{
+                "encrypt_for_multiple requires either 1 or recipients.size() messages"};
+
+    size_t max_msg_size = 0;
+    for (const auto& m : messages)
+        if (auto sz = m.size(); sz > max_msg_size)
+            max_msg_size = sz;
+
+    ustring encrypted;
+    encrypted.reserve(max_msg_size + encrypt_multiple_message_overhead);
+
+    sodium_cleared<std::array<unsigned char, 32>> key;
+    auto msg_it = messages.begin();
+    for (const auto& r : recipients) {
+        const auto& m = *msg_it;
+        if (messages.size() > 1)
+            ++msg_it;
+        try {
+            detail::encrypt_multi_key(key, privkey.data(), pubkey.data(), r.data(), true, domain);
+        } catch (const std::exception&) {
+            if (ignore_invalid_recipient)
+                continue;
+            else
+                throw;
+        }
+        detail::encrypt_multi_impl(encrypted, m, key.data(), nonce.data());
+        call(ustring_view{encrypted});
+    }
+}
+
+/// Wrapper for passing a single message for all recipients; all arguments other than the first are
+/// identical.
+template <typename... Args>
+void encrypt_for_multiple(ustring_view message, Args&&... args) {
+    return encrypt_for_multiple(
+            to_view_vector(&message, &message + 1), std::forward<Args>(args)...);
+}
+template <typename... Args>
+void encrypt_for_multiple(std::string_view message, Args&&... args) {
+    return encrypt_for_multiple(to_unsigned_sv(message), std::forward<Args>(args)...);
+}
+template <typename... Args>
+void encrypt_for_multiple(std::basic_string_view<std::byte> message, Args&&... args) {
+    return encrypt_for_multiple(to_unsigned_sv(message), std::forward<Args>(args)...);
+}
+
+/// API: crypto/decrypt_for_multiple
+///
+/// Decryption via a lambda: we call the lambda (which must return a std::optional<ustring_view>)
+/// repeatedly until we get back a nullopt, and attempt to decrypt each returned value.  When
+/// decryption succeeds, we return the plaintext to the caller.  If none of the fed-in values can be
+/// decrypt, we return std::nullopt.
+///
+/// Inputs:
+/// - `ciphertext` -- callback that returns a std::optional<ustring> or std::optional<ustring_view>
+///   when called, containing the next ciphertext; should return std::nullopt when finished.
+/// - `nonce` -- the nonce used for encryption/decryption (which must have been provided by the
+///   sender alongside the encrypted messages, and is the same as the `nonce` value given to
+///   `encrypt_for_multiple`)
+/// - `privkey` -- the private X25519 key of the recipient.
+/// - `pubkey` -- the public X25519 key of the recipient (for a successful decryption, this will be
+///   one of the pubkeys given to `encrypt_for_multiple`.
+/// - `sender_pubkey` -- the public X25519 key of the sender (this is the `pubkey` passed into
+///   `encrypt_for_multiple`).
+/// - `domain` -- the encryption domain; this is typically a hard-coded string, and must be the same
+///   as the one used for encryption.
+template <
+        typename NextCiphertext,
+        typename = std::enable_if_t<
+                std::is_invocable_r_v<std::optional<ustring_view>, NextCiphertext> ||
+                std::is_invocable_r_v<std::optional<ustring>, NextCiphertext> ||
+                std::is_invocable_r_v<std::optional<std::string_view>, NextCiphertext> ||
+                std::is_invocable_r_v<std::optional<std::string>, NextCiphertext> ||
+                std::is_invocable_r_v<
+                        std::optional<std::basic_string_view<std::byte>>,
+                        NextCiphertext> ||
+                std::is_invocable_r_v<std::optional<std::basic_string<std::byte>>, NextCiphertext>>>
+std::optional<ustring> decrypt_for_multiple(
+        NextCiphertext next_ciphertext,
+        ustring_view nonce,
+        ustring_view privkey,
+        ustring_view pubkey,
+        ustring_view sender_pubkey,
+        std::string_view domain) {
+
+    detail::validate_multi_fields(nonce, privkey, pubkey);
+    if (sender_pubkey.size() != 32)
+        throw std::logic_error{"pubkey requires a 32-byte pubkey"};
+
+    sodium_cleared<std::array<unsigned char, 32>> key;
+    detail::encrypt_multi_key(
+            key, privkey.data(), pubkey.data(), sender_pubkey.data(), false, domain);
+
+    auto decrypted = std::make_optional<ustring>();
+
+    for (auto ciphertext = next_ciphertext(); ciphertext; ciphertext = next_ciphertext())
+        if (detail::decrypt_multi_impl(*decrypted, *ciphertext, key.data(), nonce.data()))
+            return decrypted;
+
+    decrypted.reset();
+    return decrypted;
+}
+
+/// API: crypto/decrypt_for_multiple
+///
+/// Attempts to decrypt any of the messages produced by `encrypt_for_multiple`.  As soon as one
+/// decrypts successfully it is returned.  If non decrypt you get back std::nullopt.
+///
+/// Inputs:
+/// - `ciphertexts` -- the encrypted values
+/// - `nonce` -- the nonce used for encryption/decryption (which must have been provided by the
+///   sender alongside the encrypted messages, and is the same as the `nonce` value given to
+///   `encrypt_for_multiple`)
+/// - `privkey` -- the private X25519 key of the recipient.
+/// - `pubkey` -- the public X25519 key of the recipient (for a successful decryption, this will be
+///   one of the pubkeys given to `encrypt_for_multiple`.
+/// - `sender_pubkey` -- the public X25519 key of the sender (this is the `pubkey` passed into
+///   `encrypt_for_multiple`).
+/// - `domain` -- the encryption domain; this is typically a hard-coded string, and must be the same
+///   as the one used for encryption.
+///
+std::optional<ustring> decrypt_for_multiple(
+        const std::vector<ustring_view>& ciphertexts,
+        ustring_view nonce,
+        ustring_view privkey,
+        ustring_view pubkey,
+        ustring_view sender_pubkey,
+        std::string_view domain);
+
+
+
+}  // namespace session

--- a/include/session/util.hpp
+++ b/include/session/util.hpp
@@ -319,8 +319,9 @@ using string_view_char_type = std::conditional_t<
 template <typename T>
 constexpr bool is_char_array = false;
 template <typename Char, size_t N>
-inline constexpr bool is_char_array<std::array<Char, N>> = std::is_same_v<Char, char> || std::is_same_v<Char, unsigned char> || std::is_same_v<Char, std::byte>;
-
+inline constexpr bool is_char_array<std::array<Char, N>> =
+        std::is_same_v<Char, char> || std::is_same_v<Char, unsigned char> ||
+        std::is_same_v<Char, std::byte>;
 
 /// Takes a container of string-like binary values and returns a vector of ustring_views viewing
 /// those values.  This can be used on a container of any type with a `.data()` and a `.size()`
@@ -340,10 +341,13 @@ std::vector<ustring_view> to_view_vector(It begin, It end) {
     std::vector<ustring_view> vec;
     vec.reserve(std::distance(begin, end));
     for (; begin != end; ++begin) {
-        if constexpr (std::is_same_v<std::remove_cv_t<decltype(*begin)>, char*>) // C strings
+        if constexpr (std::is_same_v<std::remove_cv_t<decltype(*begin)>, char*>)  // C strings
             vec.emplace_back(*begin);
         else {
-            static_assert(sizeof(*begin->data()) == 1, "to_view_vector can only be used with containers of string-like types of 1-byte characters");
+            static_assert(
+                    sizeof(*begin->data()) == 1,
+                    "to_view_vector can only be used with containers of string-like types of "
+                    "1-byte characters");
             vec.emplace_back(reinterpret_cast<const unsigned char*>(begin->data()), begin->size());
         }
     }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,9 +47,10 @@ endif()
 
 add_libsession_util_library(crypto
     blinding.cpp
+    multi_encrypt.cpp
     session_encrypt.cpp
-    xed25519.cpp
     util.cpp
+    xed25519.cpp
 )
 
 add_libsession_util_library(config

--- a/src/config/groups/keys.cpp
+++ b/src/config/groups/keys.cpp
@@ -1002,7 +1002,8 @@ bool Keys::load_key_message(
 
         // Ensure we consume all the ciphertexts (to ensure some message validity, even if we found
         // one halfway through).
-        while (next_ciphertext()) {}
+        while (next_ciphertext()) {
+        }
 
         if (!d.skip_until("G"))
             throw config_value_error{
@@ -1079,7 +1080,8 @@ bool Keys::load_key_message(
 
         // Parse them all, even once we had a successful decryption, to properly count and fail on
         // invalid input:
-        while (next_ciphertext()) {}
+        while (next_ciphertext()) {
+        }
 
         if (++member_key_pos % MESSAGE_KEY_MULTIPLE != 0)
             throw config_value_error{"Member key list has wrong size (missing junk key padding?)"};

--- a/src/multi_encrypt.cpp
+++ b/src/multi_encrypt.cpp
@@ -1,0 +1,110 @@
+
+#include <oxenc/bt_producer.h>
+#include <oxenc/bt_serialize.h>
+#include <sodium/crypto_aead_xchacha20poly1305.h>
+#include <sodium/crypto_generichash_blake2b.h>
+#include <sodium/crypto_scalarmult_curve25519.h>
+#include <sodium/crypto_sign_ed25519.h>
+#include <sodium/randombytes.h>
+
+#include <session/multi_encrypt.hpp>
+#include <stdexcept>
+
+namespace session {
+
+const size_t encrypt_multiple_message_overhead = crypto_aead_xchacha20poly1305_ietf_ABYTES;
+
+namespace detail {
+
+    void encrypt_multi_key(
+            std::array<unsigned char, 32>& key,
+            const unsigned char* a,
+            const unsigned char* A,
+            const unsigned char* B,
+            bool encrypting,
+            std::string_view domain) {
+
+        std::array<unsigned char, 32> buf;
+        if (0 != crypto_scalarmult_curve25519(buf.data(), a, B))
+            throw std::invalid_argument{"Unable to compute shared encrypted key: invalid pubkey?"};
+
+        static_assert(crypto_aead_xchacha20poly1305_ietf_KEYBYTES == 32);
+
+        crypto_generichash_blake2b_state st;
+        crypto_generichash_blake2b_init(
+                &st,
+                reinterpret_cast<const unsigned char*>(domain.data()),
+                std::min<size_t>(domain.size(), crypto_generichash_blake2b_KEYBYTES_MAX),
+                32);
+
+        crypto_generichash_blake2b_update(&st, buf.data(), buf.size());
+
+        // If we're encrypting then a/A == sender, B = recipient
+        // If we're decrypting then a/A = recipient, B = sender
+        // We always need the same sR || S || R or rS || S || R, so if we're decrypting we need to
+        // put B before A in the hash;
+        const auto* S = encrypting ? A : B;
+        const auto* R = encrypting ? B : A;
+        crypto_generichash_blake2b_update(&st, S, 32);
+        crypto_generichash_blake2b_update(&st, R, 32);
+        crypto_generichash_blake2b_final(&st, key.data(), 32);
+    }
+
+    void encrypt_multi_impl(
+            ustring& out, ustring_view msg, const unsigned char* key, const unsigned char* nonce) {
+
+        //        auto key = encrypt_multi_key(a, A, B, true, domain);
+
+        out.resize(msg.size() + crypto_aead_xchacha20poly1305_ietf_ABYTES);
+        if (0 !=
+            crypto_aead_xchacha20poly1305_ietf_encrypt(
+                    out.data(), nullptr, msg.data(), msg.size(), nullptr, 0, nullptr, nonce, key))
+            throw std::runtime_error{"XChaCha20 encryption failed!"};
+    }
+
+    bool decrypt_multi_impl(
+            ustring& out,
+            ustring_view ciphertext,
+            const unsigned char* key,
+            const unsigned char* nonce) {
+
+        if (ciphertext.size() < crypto_aead_xchacha20poly1305_ietf_ABYTES)
+            return false;
+
+        out.resize(ciphertext.size() - crypto_aead_xchacha20poly1305_ietf_ABYTES);
+        return 0 == crypto_aead_xchacha20poly1305_ietf_decrypt(
+                            out.data(),
+                            nullptr,
+                            nullptr,
+                            ciphertext.data(),
+                            ciphertext.size(),
+                            nullptr,
+                            0,
+                            nonce,
+                            key);
+    }
+
+}  // namespace detail
+
+std::optional<ustring> decrypt_for_multiple(
+        const std::vector<ustring_view>& ciphertexts,
+        ustring_view nonce,
+        ustring_view privkey,
+        ustring_view pubkey,
+        ustring_view sender_pubkey,
+        std::string_view domain) {
+
+    auto it = ciphertexts.begin();
+    return decrypt_for_multiple(
+            [&]() -> std::optional<ustring_view> {
+                if (it == ciphertexts.end())
+                    return std::nullopt;
+                return *it++;
+            },
+            nonce,
+            privkey,
+            pubkey,
+            sender_pubkey,
+            domain);
+}
+}  // namespace session

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(testAll
     test_group_keys.cpp
     test_group_info.cpp
     test_group_members.cpp
+    test_multi_encrypt.cpp
     test_onionreq.cpp
     test_proto.cpp
     test_session_encrypt.cpp

--- a/tests/test_multi_encrypt.cpp
+++ b/tests/test_multi_encrypt.cpp
@@ -1,0 +1,189 @@
+#include <sodium/crypto_sign_ed25519.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <session/multi_encrypt.hpp>
+#include <session/util.hpp>
+
+#include "utils.hpp"
+
+using namespace std::literals;
+using namespace oxenc::literals;
+
+using x_pair = std::pair<std::array<unsigned char, 32>, std::array<unsigned char, 32>>;
+
+// Returns X25519 privkey, pubkey from an Ed25519 seed
+x_pair to_x_keys(ustring_view ed_seed) {
+    std::array<unsigned char, 32> ed_pk;
+    std::array<unsigned char, 64> ed_sk;
+    crypto_sign_ed25519_seed_keypair(ed_pk.data(), ed_sk.data(), ed_seed.data());
+    x_pair ret;
+    auto& [x_priv, x_pub] = ret;
+    [[maybe_unused]] int rc = crypto_sign_ed25519_pk_to_curve25519(x_pub.data(), ed_pk.data());
+    assert(rc == 0);
+    crypto_sign_ed25519_sk_to_curve25519(x_priv.data(), ed_sk.data());
+    return ret;
+}
+
+TEST_CASE("Multi-recipient encryption", "[encrypt][multi]") {
+
+    const std::array seeds = {
+            "0123456789abcdef0123456789abcdef00000000000000000000000000000000"_hexbytes,
+            "0123456789abcdef000000000000000000000000000000000000000000000000"_hexbytes,
+            "0123456789abcdef111111111111111100000000000000000000000000000000"_hexbytes,
+            "0123456789abcdef222222222222222200000000000000000000000000000000"_hexbytes,
+            "0123456789abcdef333333333333333300000000000000000000000000000000"_hexbytes};
+
+    std::array<x_pair, seeds.size()> x_keys;
+    for (int i = 0; i < seeds.size(); i++)
+        x_keys[i] = to_x_keys(seeds[i]);
+
+    CHECK(oxenc::to_hex(to_usv(x_keys[0].second)) ==
+          "d2ad010eeb72d72e561d9de7bd7b6989af77dcabffa03a5111a6c859ae5c3a72");
+    CHECK(oxenc::to_hex(to_usv(x_keys[1].second)) ==
+          "d673a8fb4800d2a252d2fc4e3342a88cdfa9412853934e8993d12d593be13371");
+    CHECK(oxenc::to_hex(to_usv(x_keys[2].second)) ==
+          "afd9716ea69ab8c7f475e1b250c86a6539e260804faecf2a803e9281a4160738");
+    CHECK(oxenc::to_hex(to_usv(x_keys[3].second)) ==
+          "03be14feabd59122349614b88bdc90db1d1af4c230e9a73c898beec833d51f11");
+    CHECK(oxenc::to_hex(to_usv(x_keys[4].second)) ==
+          "27b5c1ea87cef76284c752fa6ee1b9186b1a95e74e8f5b88f8b47e5191ce6f08");
+
+    auto nonce = "32ab4bb45d6df5cc14e1c330fb1a8b68ea3826a8c2213a49"_hexbytes;
+
+    std::vector<ustring_view> recipients;
+    for (auto& [_, pubkey] : x_keys)
+        recipients.emplace_back(pubkey.data(), pubkey.size());
+
+    std::vector<std::string> msgs{{"hello", "cruel", "world"}};
+    std::vector<ustring> encrypted;
+    session::encrypt_for_multiple(
+            msgs[0],
+            session::to_view_vector(std::next(recipients.begin()), std::prev(recipients.end())),
+            nonce,
+            to_usv(x_keys[0].first),
+            to_usv(x_keys[0].second),
+            "test suite",
+            [&](ustring_view enc) { encrypted.emplace_back(enc); });
+
+    REQUIRE(encrypted.size() == 3);
+    CHECK(oxenc::to_hex(encrypted[0]) == "e64937e5ea201b84f4e88a976dad900d91caaf6a17");
+    CHECK(oxenc::to_hex(encrypted[1]) == "b7a15bcd9f7b09445defcae2f1dc5085dd75cb085b");
+    CHECK(oxenc::to_hex(encrypted[2]) == "01c4fc2156327735f3fb5063b11ea95f6ebcc5b6cc");
+
+    auto m1 = session::decrypt_for_multiple(
+            session::to_view_vector(encrypted),
+            nonce,
+            to_usv(x_keys[1].first),
+            to_usv(x_keys[1].second),
+            to_usv(x_keys[0].second),
+            "test suite");
+    auto m2 = session::decrypt_for_multiple(
+            session::to_view_vector(encrypted),
+            nonce,
+            to_usv(x_keys[2].first),
+            to_usv(x_keys[2].second),
+            to_usv(x_keys[0].second),
+            "test suite");
+    auto m3 = session::decrypt_for_multiple(
+            session::to_view_vector(encrypted),
+            nonce,
+            to_usv(x_keys[3].first),
+            to_usv(x_keys[3].second),
+            to_usv(x_keys[0].second),
+            "test suite");
+    auto m3b = session::decrypt_for_multiple(
+            session::to_view_vector(encrypted),
+            nonce,
+            to_usv(x_keys[3].first),
+            to_usv(x_keys[3].second),
+            to_usv(x_keys[0].second),
+            "not test suite");
+    auto m4 = session::decrypt_for_multiple(
+            session::to_view_vector(encrypted),
+            nonce,
+            to_usv(x_keys[4].first),
+            to_usv(x_keys[4].second),
+            to_usv(x_keys[0].second),
+            "test suite");
+
+    REQUIRE(m1);
+    REQUIRE(m2);
+    REQUIRE(m3);
+    CHECK_FALSE(m3b);
+    CHECK_FALSE(m4);
+
+    CHECK(to_sv(*m1) == "hello");
+    CHECK(to_sv(*m2) == "hello");
+    CHECK(to_sv(*m3) == "hello");
+
+    encrypted.clear();
+    session::encrypt_for_multiple(
+            session::to_view_vector(msgs.begin(), msgs.end()),
+            session::to_view_vector(std::next(recipients.begin()), std::prev(recipients.end())),
+            nonce,
+            to_usv(x_keys[0].first),
+            to_usv(x_keys[0].second),
+            "test suite",
+            [&](ustring_view enc) { encrypted.emplace_back(enc); });
+
+    REQUIRE(encrypted.size() == 3);
+    CHECK(oxenc::to_hex(encrypted[0]) == "e64937e5ea201b84f4e88a976dad900d91caaf6a17");
+    CHECK(oxenc::to_hex(encrypted[1]) == "bcb642c49c6da03f70cdaab2ed6666721318afd631");
+    CHECK(oxenc::to_hex(encrypted[2]) == "1ecee2215d226817edfdb097f05037eb799309103a");
+
+    m1 = session::decrypt_for_multiple(
+            session::to_view_vector(encrypted),
+            nonce,
+            to_usv(x_keys[1].first),
+            to_usv(x_keys[1].second),
+            to_usv(x_keys[0].second),
+            "test suite");
+    m2 = session::decrypt_for_multiple(
+            session::to_view_vector(encrypted),
+            nonce,
+            to_usv(x_keys[2].first),
+            to_usv(x_keys[2].second),
+            to_usv(x_keys[0].second),
+            "test suite");
+    m3 = session::decrypt_for_multiple(
+            session::to_view_vector(encrypted),
+            nonce,
+            to_usv(x_keys[3].first),
+            to_usv(x_keys[3].second),
+            to_usv(x_keys[0].second),
+            "test suite");
+    m3b = session::decrypt_for_multiple(
+            session::to_view_vector(encrypted),
+            nonce,
+            to_usv(x_keys[3].first),
+            to_usv(x_keys[3].second),
+            to_usv(x_keys[0].second),
+            "not test suite");
+    m4 = session::decrypt_for_multiple(
+            session::to_view_vector(encrypted),
+            nonce,
+            to_usv(x_keys[4].first),
+            to_usv(x_keys[4].second),
+            to_usv(x_keys[0].second),
+            "test suite");
+
+    REQUIRE(m1);
+    REQUIRE(m2);
+    REQUIRE(m3);
+    CHECK_FALSE(m3b);
+    CHECK_FALSE(m4);
+
+    CHECK(to_sv(*m1) == "hello");
+    CHECK(to_sv(*m2) == "cruel");
+    CHECK(to_sv(*m3) == "world");
+
+    // Mismatch messages & recipients size throws:
+    CHECK_THROWS(session::encrypt_for_multiple(
+            session::to_view_vector(msgs.begin(), std::prev(msgs.end())),
+            session::to_view_vector(std::next(recipients.begin()), std::prev(recipients.end())),
+            nonce,
+            to_usv(x_keys[0].first),
+            to_usv(x_keys[0].second),
+            "test suite",
+            [&](ustring_view enc) { encrypted.emplace_back(enc); }));
+}

--- a/tests/test_multi_encrypt.cpp
+++ b/tests/test_multi_encrypt.cpp
@@ -1,3 +1,4 @@
+#include <sodium/crypto_aead_xchacha20poly1305.h>
 #include <sodium/crypto_sign_ed25519.h>
 
 #include <catch2/catch_test_macros.hpp>
@@ -186,4 +187,162 @@ TEST_CASE("Multi-recipient encryption", "[encrypt][multi]") {
             to_usv(x_keys[0].second),
             "test suite",
             [&](ustring_view enc) { encrypted.emplace_back(enc); }));
+}
+
+TEST_CASE("Multi-recipient encryption, simpler interface", "[encrypt][multi][simple]") {
+
+    const std::array seeds = {
+            "0123456789abcdef0123456789abcdef00000000000000000000000000000000"_hexbytes,
+            "0123456789abcdef000000000000000000000000000000000000000000000000"_hexbytes,
+            "0123456789abcdef111111111111111100000000000000000000000000000000"_hexbytes,
+            "0123456789abcdef222222222222222200000000000000000000000000000000"_hexbytes,
+            "0123456789abcdef333333333333333300000000000000000000000000000000"_hexbytes};
+
+    std::array<x_pair, seeds.size()> x_keys;
+    for (int i = 0; i < seeds.size(); i++)
+        x_keys[i] = to_x_keys(seeds[i]);
+
+    CHECK(oxenc::to_hex(to_usv(x_keys[0].second)) ==
+          "d2ad010eeb72d72e561d9de7bd7b6989af77dcabffa03a5111a6c859ae5c3a72");
+    CHECK(oxenc::to_hex(to_usv(x_keys[1].second)) ==
+          "d673a8fb4800d2a252d2fc4e3342a88cdfa9412853934e8993d12d593be13371");
+    CHECK(oxenc::to_hex(to_usv(x_keys[2].second)) ==
+          "afd9716ea69ab8c7f475e1b250c86a6539e260804faecf2a803e9281a4160738");
+    CHECK(oxenc::to_hex(to_usv(x_keys[3].second)) ==
+          "03be14feabd59122349614b88bdc90db1d1af4c230e9a73c898beec833d51f11");
+    CHECK(oxenc::to_hex(to_usv(x_keys[4].second)) ==
+          "27b5c1ea87cef76284c752fa6ee1b9186b1a95e74e8f5b88f8b47e5191ce6f08");
+
+    auto nonce = "32ab4bb45d6df5cc14e1c330fb1a8b68ea3826a8c2213a49"_hexbytes;
+
+    std::vector<ustring_view> recipients;
+    for (auto& [_, pubkey] : x_keys)
+        recipients.emplace_back(pubkey.data(), pubkey.size());
+
+    std::vector<std::string> msgs{{"hello", "cruel", "world"}};
+    ustring encrypted = session::encrypt_for_multiple_simple(
+            msgs[0],
+            session::to_view_vector(std::next(recipients.begin()), std::prev(recipients.end())),
+            to_usv(x_keys[0].first),
+            to_usv(x_keys[0].second),
+            "test suite");
+
+    REQUIRE(encrypted.size() ==
+            /* de */ 2 +
+                    /* 1:# 24:...nonce... */ 3 + 27 +
+                    /* 1:e le */ 3 + 2 +
+                    /* XX: then data with overhead */ 3 *
+                            (3 + 5 + crypto_aead_xchacha20poly1305_ietf_ABYTES));
+
+    // If we encrypt again the value should be different (because of the default randomized nonce):
+    CHECK(encrypted != session::encrypt_for_multiple_simple(
+            msgs[0],
+            session::to_view_vector(std::next(recipients.begin()), std::prev(recipients.end())),
+            to_usv(x_keys[0].first),
+            to_usv(x_keys[0].second),
+            "test suite"));
+
+    auto m1 = session::decrypt_for_multiple_simple(
+            encrypted,
+            to_usv(x_keys[1].first),
+            to_usv(x_keys[1].second),
+            to_usv(x_keys[0].second),
+            "test suite");
+    auto m2 = session::decrypt_for_multiple_simple(
+            encrypted,
+            to_usv(x_keys[2].first),
+            to_usv(x_keys[2].second),
+            to_usv(x_keys[0].second),
+            "test suite");
+    auto m3 = session::decrypt_for_multiple_simple(
+            encrypted,
+            to_usv(x_keys[3].first),
+            to_usv(x_keys[3].second),
+            to_usv(x_keys[0].second),
+            "test suite");
+    auto m3b = session::decrypt_for_multiple_simple(
+            encrypted,
+            to_usv(x_keys[3].first),
+            to_usv(x_keys[3].second),
+            to_usv(x_keys[0].second),
+            "not test suite");
+    auto m4 = session::decrypt_for_multiple_simple(
+            encrypted,
+            to_usv(x_keys[4].first),
+            to_usv(x_keys[4].second),
+            to_usv(x_keys[0].second),
+            "test suite");
+
+    REQUIRE(m1);
+    REQUIRE(m2);
+    REQUIRE(m3);
+    CHECK_FALSE(m3b);
+    CHECK_FALSE(m4);
+
+    CHECK(to_sv(*m1) == "hello");
+    CHECK(to_sv(*m2) == "hello");
+    CHECK(to_sv(*m3) == "hello");
+
+    encrypted = session::encrypt_for_multiple_simple(
+            session::to_view_vector(msgs),
+            session::to_view_vector(std::next(recipients.begin()), std::prev(recipients.end())),
+            to_usv(x_keys[0].first),
+            to_usv(x_keys[0].second),
+            "test suite",
+            nonce);
+
+    CHECK(printable(encrypted) ==
+          printable(
+                  "d1:#24:" + "32ab4bb45d6df5cc14e1c330fb1a8b68ea3826a8c2213a49"_hex + "1:el" +
+                  "21:" + "e64937e5ea201b84f4e88a976dad900d91caaf6a17"_hex +
+                  "21:" + "bcb642c49c6da03f70cdaab2ed6666721318afd631"_hex +
+                  "21:" + "1ecee2215d226817edfdb097f05037eb799309103a"_hex + "ee"));
+
+    m1 = session::decrypt_for_multiple_simple(
+            encrypted,
+            to_usv(x_keys[1].first),
+            to_usv(x_keys[1].second),
+            to_usv(x_keys[0].second),
+            "test suite");
+    m2 = session::decrypt_for_multiple_simple(
+            encrypted,
+            to_usv(x_keys[2].first),
+            to_usv(x_keys[2].second),
+            to_usv(x_keys[0].second),
+            "test suite");
+    m3 = session::decrypt_for_multiple_simple(
+            encrypted,
+            to_usv(x_keys[3].first),
+            to_usv(x_keys[3].second),
+            to_usv(x_keys[0].second),
+            "test suite");
+    m3b = session::decrypt_for_multiple_simple(
+            encrypted,
+            to_usv(x_keys[3].first),
+            to_usv(x_keys[3].second),
+            to_usv(x_keys[0].second),
+            "not test suite");
+    m4 = session::decrypt_for_multiple_simple(
+            encrypted,
+            to_usv(x_keys[4].first),
+            to_usv(x_keys[4].second),
+            to_usv(x_keys[0].second),
+            "test suite");
+
+    REQUIRE(m1);
+    REQUIRE(m2);
+    REQUIRE(m3);
+    CHECK_FALSE(m3b);
+    CHECK_FALSE(m4);
+
+    CHECK(to_sv(*m1) == "hello");
+    CHECK(to_sv(*m2) == "cruel");
+    CHECK(to_sv(*m3) == "world");
+
+    CHECK_THROWS(session::encrypt_for_multiple_simple(
+            session::to_view_vector(msgs.begin(), std::prev(msgs.end())),
+            session::to_view_vector(std::next(recipients.begin()), std::prev(recipients.end())),
+            to_usv(x_keys[0].first),
+            to_usv(x_keys[0].second),
+            "test suite"));
 }

--- a/tests/test_multi_encrypt.cpp
+++ b/tests/test_multi_encrypt.cpp
@@ -236,11 +236,12 @@ TEST_CASE("Multi-recipient encryption, simpler interface", "[encrypt][multi][sim
 
     // If we encrypt again the value should be different (because of the default randomized nonce):
     CHECK(encrypted != session::encrypt_for_multiple_simple(
-            msgs[0],
-            session::to_view_vector(std::next(recipients.begin()), std::prev(recipients.end())),
-            to_usv(x_keys[0].first),
-            to_usv(x_keys[0].second),
-            "test suite"));
+                               msgs[0],
+                               session::to_view_vector(
+                                       std::next(recipients.begin()), std::prev(recipients.end())),
+                               to_usv(x_keys[0].first),
+                               to_usv(x_keys[0].second),
+                               "test suite"));
 
     auto m1 = session::decrypt_for_multiple_simple(
             encrypted,


### PR DESCRIPTION
This allows efficiently encrypting 1-to-N or N-to-N messages in a single message, such as is used in the group keys message.

This adds both a general C++ interface (which is now used by the group keys code) for constructing such encrypted messages generically, and adds a version suffixed with `_simple` that produces ready-to-go bt-encoded binary values containing the nonce + encrypted values.