### PR TITLE
ConvoInfoVolatile: fix new group iteration

### DIFF
--- a/include/session/config/convo_info_volatile.hpp
+++ b/include/session/config/convo_info_volatile.hpp
@@ -21,6 +21,7 @@ struct convo_info_volatile_legacy_group;
 namespace session::config {
 
 class ConvoInfoVolatile;
+class val_loader;
 
 /// keys used in this config, either currently or in the past (so that we don't reuse):
 ///
@@ -63,6 +64,8 @@ namespace convo {
 
       protected:
         void load(const dict& info_dict);
+        friend class session::config::val_loader;
+        friend class session::config::ConvoInfoVolatile;
     };
 
     struct one_to_one : base {
@@ -87,8 +90,6 @@ namespace convo {
         // Internal ctor/method for C API implementations:
         one_to_one(const struct convo_info_volatile_1to1& c);  // From c struct
         void into(convo_info_volatile_1to1& c) const;          // Into c struct
-
-        friend class session::config::ConvoInfoVolatile;
     };
 
     struct community : config::community, base {
@@ -123,9 +124,6 @@ namespace convo {
         // Internal ctor/method for C API implementations:
         group(const struct convo_info_volatile_group& c);  // From c struct
         void into(convo_info_volatile_group& c) const;     // Into c struct
-
-      private:
-        friend class session::config::ConvoInfoVolatile;
     };
 
     struct legacy_group : base {
@@ -149,9 +147,6 @@ namespace convo {
         // Internal ctor/method for C API implementations:
         legacy_group(const struct convo_info_volatile_legacy_group& c);  // From c struct
         void into(convo_info_volatile_legacy_group& c) const;            // Into c struct
-
-      private:
-        friend class session::config::ConvoInfoVolatile;
     };
 
     using any = std::variant<one_to_one, community, group, legacy_group>;

--- a/tests/test_config_convo_info_volatile.cpp
+++ b/tests/test_config_convo_info_volatile.cpp
@@ -155,10 +155,19 @@ TEST_CASE("Conversations", "[config][conversations]") {
     CHECK(std::get<seqno_t>(convos.push()) == seqno);
 
     using session::config::convo::community;
+    using session::config::convo::group;
     using session::config::convo::legacy_group;
     using session::config::convo::one_to_one;
 
-    std::vector<std::string> seen;
+    std::vector<std::string> seen, expected;
+    for (const auto& e :
+         {"1-to-1: 051111111111111111111111111111111111111111111111111111111111111111",
+          "1-to-1: 055000000000000000000000000000000000000000000000000000000000000000",
+          "gr: 030111101001001000101010011011010010101010111010000110100001210000",
+          "comm: http://example.org:5678/r/sudokuroom",
+          "lgr: 05cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"})
+        expected.emplace_back(e);
+
     for (auto* conv : {&convos, &convos2}) {
         // Iterate through and make sure we got everything we expected
         seen.clear();
@@ -166,26 +175,23 @@ TEST_CASE("Conversations", "[config][conversations]") {
         CHECK(conv->size_1to1() == 2);
         CHECK(conv->size_communities() == 1);
         CHECK(conv->size_legacy_groups() == 1);
+        CHECK(conv->size_groups() == 1);
         CHECK_FALSE(conv->empty());
         for (const auto& convo : *conv) {
             if (auto* c = std::get_if<one_to_one>(&convo))
                 seen.push_back("1-to-1: "s + c->session_id);
+            else if (auto* c = std::get_if<group>(&convo))
+                seen.push_back("gr: " + c->id);
             else if (auto* c = std::get_if<community>(&convo))
                 seen.push_back(
-                        "og: " + std::string{c->base_url()} + "/r/" + std::string{c->room()});
+                        "comm: " + std::string{c->base_url()} + "/r/" + std::string{c->room()});
             else if (auto* c = std::get_if<legacy_group>(&convo))
-                seen.push_back("cl: " + c->id);
+                seen.push_back("lgr: " + c->id);
+            else
+                seen.push_back("unknown convo type!");
         }
 
-        CHECK(seen == std::vector<std::string>{
-                              {"1-to-1: "
-                               "051111111111111111111111111111111111111111111111111111111111111111",
-                               "1-to-1: "
-                               "055000000000000000000000000000000000000000000000000000000000000000",
-                               "og: http://example.org:5678/r/sudokuroom",
-                               "cl: "
-                               "05ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
-                               "c"}});
+        CHECK(seen == expected);
     }
 
     CHECK_FALSE(convos.needs_push());
@@ -388,9 +394,9 @@ TEST_CASE("Conversations (C API)", "[config][conversations][c]") {
             if (convo_info_volatile_it_is_1to1(it, &c1)) {
                 seen.push_back("1-to-1: "s + c1.session_id);
             } else if (convo_info_volatile_it_is_community(it, &c2)) {
-                seen.push_back("og: "s + c2.base_url + "/r/" + c2.room);
+                seen.push_back("comm: "s + c2.base_url + "/r/" + c2.room);
             } else if (convo_info_volatile_it_is_legacy_group(it, &c3)) {
-                seen.push_back("cl: "s + c3.group_id);
+                seen.push_back("lgr: "s + c3.group_id);
             }
         }
         convo_info_volatile_iterator_free(it);
@@ -400,8 +406,8 @@ TEST_CASE("Conversations (C API)", "[config][conversations][c]") {
                                "051111111111111111111111111111111111111111111111111111111111111111",
                                "1-to-1: "
                                "055000000000000000000000000000000000000000000000000000000000000000",
-                               "og: http://example.org:5678/r/sudokuroom",
-                               "cl: "
+                               "comm: http://example.org:5678/r/sudokuroom",
+                               "lgr: "
                                "05ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
                                "c"}});
     }


### PR DESCRIPTION
The all-convo iterators were not properly using the new groups iterators.  This fixes it, and DRYs the nearly-identical iterator handling code a bit.