### PR TITLE
Removed the default rekey from the Keys init

### DIFF
--- a/include/session/config/groups/keys.h
+++ b/include/session/config/groups/keys.h
@@ -31,6 +31,11 @@ typedef struct config_group_keys {
 /// `config_free()` and similar methods from `session/config/base.h`; instead it must be managed by
 /// the functions declared in the header.
 ///
+/// When no dump is provided the initial config_group_keys object will be created with no keys
+/// loaded at all, these will be loaded later into this and the info/members objects when loading
+/// keys via received config messages. If this is a brand new group then groups_keys_rekey() MUST be
+/// called, otherwise the group will be in an invalid state.
+///
 /// Inputs:
 /// - `conf` -- [out] Pointer-pointer to a `config_group_keys` pointer (i.e. double pointer); the
 ///   pointer will be set to a new config_group_keys object on success.

--- a/include/session/config/groups/keys.hpp
+++ b/include/session/config/groups/keys.hpp
@@ -164,6 +164,11 @@ class Keys final : public ConfigSig {
     /// To construct a blank info object (i.e. with no pre-existing dumped data to load) pass
     /// `std::nullopt` as the last argument.
     ///
+    /// When no dump is provided the initial Keys object will be created with no keys loaded at all,
+    /// these will be loaded later into this and the info/members objects when loading keys via
+    /// received config messages. If this is a brand new group then rekey() MUST be called,
+    /// otherwise the group will be in an invalid state.
+    ///
     /// Inputs:
     /// - `user_ed25519_secretkey` is the ed25519 secret key backing the current user's session ID,
     ///   and is used to decrypt incoming keys.  It is required.
@@ -175,10 +180,6 @@ class Keys final : public ConfigSig {
     /// - `dumped` -- either `std::nullopt` to construct a new, empty object; or binary state data
     ///   that was previously dumped from an instance of this class by calling `dump()`.
     /// - `info` and `members` -- will be loaded with the group keys, if present in the dump.
-    ///   Otherwise, if this is an admin Keys object, with a new one constructed for the initial
-    ///   Keys object; or with no keys loaded at all if this is a non-admin, non-dump construction.
-    ///   (Keys will also be loaded later into this and the info/members objects, when rekey()ing or
-    ///   loading keys via received config messages).
     Keys(ustring_view user_ed25519_secretkey,
          ustring_view group_ed25519_pubkey,
          std::optional<ustring_view> group_ed25519_secretkey,

--- a/src/config/groups/keys.cpp
+++ b/src/config/groups/keys.cpp
@@ -59,8 +59,6 @@ Keys::Keys(
         auto key_list = group_keys();
         members.replace_keys(key_list, /*dirty=*/false);
         info.replace_keys(key_list, /*dirty=*/false);
-    } else if (admin()) {
-        rekey(info, members);
     }
 }
 
@@ -1472,7 +1470,7 @@ LIBSESSION_C_API bool groups_keys_rekey(
         config_object* members,
         const unsigned char** out,
         size_t* outlen) {
-    assert(info && members && out && outlen);
+    assert(info && members);
     auto& keys = unbox(conf);
     ustring_view to_push;
     try {
@@ -1481,8 +1479,10 @@ LIBSESSION_C_API bool groups_keys_rekey(
         set_error(conf, e.what());
         return false;
     }
-    *out = to_push.data();
-    *outlen = to_push.size();
+    if (out && outlen) {
+        *out = to_push.data();
+        *outlen = to_push.size();
+    }
     return true;
 }
 

--- a/tests/test_group_keys.cpp
+++ b/tests/test_group_keys.cpp
@@ -83,7 +83,10 @@ struct pseudo_client {
                  admin ? std::make_optional<ustring_view>({*gsk, 64}) : std::nullopt,
                  keys_dump,
                  info,
-                 members} {}
+                 members} {
+        if (gsk)
+            keys.rekey(info, members);
+    }
 };
 
 TEST_CASE("Group Keys - C++ API", "[config][groups][keys][cpp]") {
@@ -588,6 +591,9 @@ TEST_CASE("Group Keys - C API", "[config][groups][keys][c]") {
                     0,
                     NULL);
             REQUIRE(rv == 0);
+
+            if (is_admin)
+                REQUIRE(groups_keys_rekey(keys, info, members, nullptr, nullptr));
         }
 
         ~pseudo_client() {


### PR DESCRIPTION
There is a fun behaviour where when one device creates a group and adds members it generates an initial key (containing the members) but when a linked device creates an empty group state (pending the first poll) it ends up generating a new keys with no members.

Since the key used for encryption is based on the created timestamp this second "empty" key ends up incorrectly getting used.

This PR removes the default `rekey` that was called when initialising the `Keys` object, devs will need to manually call it when they are ready to create the initial key (this way the linked device won't create an invalid "empty" key).