### PR TITLE
Add static submodule libs to bundled libsession-util

### DIFF
--- a/cmake/AddStaticBundleLib.cmake
+++ b/cmake/AddStaticBundleLib.cmake
@@ -1,6 +1,11 @@
 
 set(LIBSESSION_STATIC_BUNDLE_LIBS "" CACHE INTERNAL "list of libs to go into the static bundle lib")
 
+function(_libsession_static_bundle_append tgt)
+    list(APPEND LIBSESSION_STATIC_BUNDLE_LIBS "${tgt}")
+    set(LIBSESSION_STATIC_BUNDLE_LIBS "${LIBSESSION_STATIC_BUNDLE_LIBS}" CACHE INTERNAL "")
+endfunction()
+
 # Call as:
 #
 #     libsession_static_bundle(target [target2 ...])
@@ -8,7 +13,18 @@ set(LIBSESSION_STATIC_BUNDLE_LIBS "" CACHE INTERNAL "list of libs to go into the
 # to append the given target(s) to the list of libraries that will be combined to make the static
 # bundled libsession-util.a.
 function(libsession_static_bundle)
-    list(APPEND LIBSESSION_STATIC_BUNDLE_LIBS "${ARGN}")
-    list(REMOVE_DUPLICATES LIBSESSION_STATIC_BUNDLE_LIBS)
-    set(LIBSESSION_STATIC_BUNDLE_LIBS "${LIBSESSION_STATIC_BUNDLE_LIBS}" CACHE INTERNAL "")
+    foreach(tgt IN LISTS ARGN)
+        if(TARGET "${tgt}" AND NOT "${tgt}" IN_LIST LIBSESSION_STATIC_BUNDLE_LIBS)
+            get_target_property(tgt_type ${tgt} TYPE)
+            if(tgt_type STREQUAL STATIC_LIBRARY)
+                message(STATUS "Adding ${tgt} to libsession-util bundled library list")
+                _libsession_static_bundle_append("${tgt}")
+            endif()
+
+            get_target_property(tgt_link_deps ${tgt} LINK_LIBRARIES)
+            if(tgt_link_deps)
+                libsession_static_bundle(${tgt_link_deps})
+            endif()
+        endif()
+    endforeach()
 endfunction()

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -57,6 +57,9 @@ macro(system_or_submodule BIGNAME smallname pkgconf subdir)
   if(NOT TARGET ${smallname}::${smallname})
     add_library(${smallname}::${smallname} ALIAS ${smallname})
   endif()
+  if(BUILD_STATIC_DEPS AND STATIC_BUNDLE)
+      libsession_static_bundle(${smallname}::${smallname})
+  endif()
 endmacro()
 
 


### PR DESCRIPTION
This automatically adds anything that we include via system_or_submodule into the libsession-util bundled library, most notably included libquic (in other upcoming PRs).

It also updates the libsession_static_bundle function so that only static library targets are actually bundled so that passing things like oxenc::oxenc (which is header-only and so not a static lib) just get silently ignored.