### PR TITLE
Added code to handle unwrapping double-wrapped config messages

### DIFF
--- a/src/config/base.cpp
+++ b/src/config/base.cpp
@@ -84,10 +84,6 @@ std::vector<std::string> ConfigBase::merge(
                             ustring_view{_keys.front().data(), _keys.front().size()},
                             unwrapped,
                             storage_namespace());
-                    log::warning(
-                            cat,
-                            "Found double wraped message in namespace {}",
-                            static_cast<std::int16_t>(storage_namespace()));
                     parsed.emplace_back(h, keep_alive.emplace_back(std::move(unwrapped2)));
                 } catch (...) {
                     parsed.emplace_back(h, keep_alive.emplace_back(std::move(unwrapped)));


### PR DESCRIPTION
It looks like there was an Android release which resulted in double-wrapped config messages (I'm guessing the `libSession` submodule was updated past version `1.1` but the original wrapping code wasn't removed from the client which resulted in both the client, and `libSession`, wrapping the config message)

This PR tries to unwrap the config message twice just in case we receive a config message from the buggy client.