### PR TITLE
Additional invite/promotion state and missing C functions

### DIFF
--- a/include/session/config/groups/keys.h
+++ b/include/session/config/groups/keys.h
@@ -74,6 +74,25 @@ LIBSESSION_EXPORT int groups_keys_init(
         size_t dumplen,
         char* error) LIBSESSION_WARN_UNUSED;
 
+/// API: base/groups_keys_free
+///
+/// Frees a config keys object created with groups_keys_init.
+///
+/// Inputs:
+/// - `conf` -- [in] Pointer to config_group_keys object
+LIBSESSION_EXPORT void groups_keys_free(config_group_keys* conf);
+
+/// API: base/groups_keys_storage_namespace
+///
+/// Returns the numeric namespace in which config_group_keys messages should be stored.
+///
+/// Inputs:
+/// - `conf` -- [in] Pointer to config_group_keys object
+///
+/// Outputs:
+/// - `int16_t` -- integer of the namespace
+LIBSESSION_EXPORT int16_t groups_keys_storage_namespace(const config_group_keys* conf);
+
 /// API: groups/groups_keys_size
 ///
 /// Returns the number of decryption keys stored in this Keys object.  Mainly for

--- a/include/session/config/groups/members.h
+++ b/include/session/config/groups/members.h
@@ -8,7 +8,7 @@ extern "C" {
 #include "../profile_pic.h"
 #include "../util.h"
 
-enum groups_members_invite_status { INVITE_SENT = 1, INVITE_FAILED = 2 };
+enum groups_members_invite_status { INVITE_SENT = 1, INVITE_FAILED = 2, INVITE_NOT_SENT = 3 };
 enum groups_members_remove_status { REMOVED_MEMBER = 1, REMOVED_MEMBER_AND_MESSAGES = 2 };
 
 typedef struct config_group_member {
@@ -19,7 +19,8 @@ typedef struct config_group_member {
     user_profile_pic profile_pic;
 
     bool admin;
-    int invited;   // 0 == unset, INVITE_SENT = invited, INVITED_FAILED = invite failed to send
+    int invited;   // 0 == unset, INVITE_SENT = invited, INVITED_FAILED = invite failed to send,
+                   // INVITE_NOT_SENT = invite hasn't been sent yet
     int promoted;  // same value as `invited`, but for promotion-to-admin
     int removed;   // 0 == unset, REMOVED_MEMBER = removed, REMOVED_MEMBER_AND_MESSAGES = remove
                    // member and their messages

--- a/include/session/config/groups/members.hpp
+++ b/include/session/config/groups/members.hpp
@@ -81,14 +81,11 @@ struct member {
     ///
     /// Member variable
     ///
-    /// Flag that is set to indicate to the group that this member is an admin.
+    /// Flag that is set to indicate to the group that this member has been promoted to an admin.
     ///
     /// Note that this is only informative but isn't a permission gate: someone could still possess
     /// the admin keys without this (e.g. if they cleared the flag to appear invisible), or could
     /// have lost (or never had) the keys even if this is set.
-    ///
-    /// See also `promoted()` if you want to check for either an admin or someone being promoted to
-    /// admin.
     bool admin = false;
 
     /// API: groups/member::supplement
@@ -129,16 +126,16 @@ struct member {
         supplement = false;
     }
 
-    /// API: groups/member::invite_needs_send
+    /// API: groups/member::invite_not_sent
     ///
-    /// Returns whether the user needs an invite sent to them.  Returns true if so (whether or
-    /// not that invitation has been sent).
+    /// Returns true if there has never been an attempt to send an invitation to the user.  Returns
+    /// false otherwise.
     ///
     /// Inputs: none
     ///
     /// Outputs:
     /// - `bool` -- true if the user needs an invitation to be sent, false otherwise.
-    bool invite_needs_send() const { return invite_status == INVITE_NOT_SENT; }
+    bool invite_not_sent() const { return invite_status == INVITE_NOT_SENT; }
 
     /// API: groups/member::invite_pending
     ///
@@ -197,25 +194,25 @@ struct member {
         promotion_status = INVITE_FAILED;
     }
 
-    /// API: groups/member::accept_promotion
+    /// API: groups/member::set_promotion_accepted
     ///
     /// This marks the user as having accepted a promotion to admin in the group.
-    void accept_promotion() {
+    void set_promotion_accepted() {
         admin = true;
         invite_status = 0;
         promotion_status = 0;
     }
 
-    /// API: groups/member::promotion_needs_send
+    /// API: groups/member::promotion_not_sent
     ///
-    /// Returns whether the user needs a promotion to admin status to be sent.
-    /// Returns true if so (whether or not that promotion has failed).
+    /// Returns true if the user is an admin but there has never been an attempt to send a promotion
+    /// to admin status sent to them. Returns false otherwise.
     ///
     /// Inputs: None
     ///
     /// Outputs:
     /// - `bool` -- true if the user needs a promotion to be sent, false otherwise.
-    bool promotion_needs_send() const { return promotion_status == INVITE_NOT_SENT; }
+    bool promotion_not_sent() const { return admin && promotion_status == INVITE_NOT_SENT; }
 
     /// API: groups/member::promotion_pending
     ///
@@ -226,7 +223,7 @@ struct member {
     ///
     /// Outputs:
     /// - `bool` -- true if the user has a pending promotion, false otherwise.
-    bool promotion_pending() const { return promotion_status > 0; }
+    bool promotion_pending() const { return admin && promotion_status > 0; }
 
     /// API: groups/member::promotion_failed
     ///
@@ -237,7 +234,7 @@ struct member {
     ///
     /// Outputs:
     /// - `bool` -- true if the user has a failed pending promotion
-    bool promotion_failed() const { return promotion_status == INVITE_FAILED; }
+    bool promotion_failed() const { return admin && promotion_status == INVITE_FAILED; }
 
     /// API: groups/member::promoted
     ///

--- a/include/session/config/groups/members.hpp
+++ b/include/session/config/groups/members.hpp
@@ -81,7 +81,8 @@ struct member {
     ///
     /// Member variable
     ///
-    /// Flag that is set to indicate to the group that this member is an admin or has been promoted to admin.
+    /// Flag that is set to indicate to the group that this member is an admin or has been promoted
+    /// to admin.
     ///
     /// Note that this is only informative but isn't a permission gate: someone could still possess
     /// the admin keys without this (e.g. if they cleared the flag to appear invisible), or could

--- a/include/session/config/groups/members.hpp
+++ b/include/session/config/groups/members.hpp
@@ -81,7 +81,7 @@ struct member {
     ///
     /// Member variable
     ///
-    /// Flag that is set to indicate to the group that this member has been promoted to an admin.
+    /// Flag that is set to indicate to the group that this member is an admin or has been promoted to admin.
     ///
     /// Note that this is only informative but isn't a permission gate: someone could still possess
     /// the admin keys without this (e.g. if they cleared the flag to appear invisible), or could

--- a/include/session/onionreq/builder.h
+++ b/include/session/onionreq/builder.h
@@ -25,12 +25,20 @@ typedef struct onion_request_builder_object {
 ///
 /// Constructs an onion request builder and sets a pointer to it in `builder`.
 ///
-/// When done with the object the `builder` must be destroyed by either passing the pointer to
-/// onion_request_builder_free() or onion_request_builder_build().
+/// When done with the object the `builder` must be destroyed by passing the pointer to
+/// onion_request_builder_free().
 ///
 /// Inputs:
 /// - `builder` -- [out] Pointer to the builder object
 LIBSESSION_EXPORT void onion_request_builder_init(onion_request_builder_object** builder);
+
+/// API: groups/onion_request_builder_free
+///
+/// Properly destroys an onion request builder instance.
+///
+/// Inputs:
+/// - `builder` -- [out] Pointer to the builder object to be freed
+LIBSESSION_EXPORT void onion_request_builder_free(onion_request_builder_object* builder);
 
 /// API: onion_request_builder_set_enc_type
 ///

--- a/src/config/base.cpp
+++ b/src/config/base.cpp
@@ -623,6 +623,7 @@ using namespace session;
 using namespace session::config;
 
 LIBSESSION_EXPORT void config_free(config_object* conf) {
+    delete static_cast<internals<>*>(conf->internals);
     delete conf;
 }
 

--- a/src/config/groups/keys.cpp
+++ b/src/config/groups/keys.cpp
@@ -1433,6 +1433,7 @@ LIBSESSION_C_API int groups_keys_init(
 }
 
 LIBSESSION_C_API void groups_keys_free(config_group_keys* conf) {
+    delete static_cast<groups::Keys*>(conf->internals);
     delete conf;
 }
 

--- a/src/config/groups/keys.cpp
+++ b/src/config/groups/keys.cpp
@@ -1432,6 +1432,14 @@ LIBSESSION_C_API int groups_keys_init(
     return SESSION_ERR_NONE;
 }
 
+LIBSESSION_C_API void groups_keys_free(config_group_keys* conf) {
+    delete conf;
+}
+
+LIBSESSION_EXPORT int16_t groups_keys_storage_namespace(const config_group_keys* conf) {
+    return static_cast<int16_t>(unbox(conf).storage_namespace());
+}
+
 LIBSESSION_C_API size_t groups_keys_size(const config_group_keys* conf) {
     return unbox(conf).size();
 }

--- a/src/config/groups/members.cpp
+++ b/src/config/groups/members.cpp
@@ -49,7 +49,7 @@ void Members::set(const member& mem) {
             mem.profile_picture.key);
 
     set_flag(info["A"], mem.admin);
-    set_positive_int(info["P"], mem.admin ? 0 : mem.promotion_status);
+    set_positive_int(info["P"], mem.promotion_status);
     set_positive_int(info["I"], mem.admin ? 0 : mem.invite_status);
     set_flag(info["s"], mem.supplement);
     set_positive_int(info["R"], mem.removed_status);
@@ -69,7 +69,7 @@ void member::load(const dict& info_dict) {
 
     admin = maybe_int(info_dict, "A").value_or(0);
     invite_status = admin ? 0 : maybe_int(info_dict, "I").value_or(0);
-    promotion_status = admin ? 0 : maybe_int(info_dict, "P").value_or(0);
+    promotion_status = maybe_int(info_dict, "P").value_or(0);
     removed_status = maybe_int(info_dict, "R").value_or(0);
     supplement = invite_pending() && !promoted() ? maybe_int(info_dict, "s").value_or(0) : 0;
 }
@@ -161,6 +161,7 @@ void member::into(config_group_member& m) const {
     m.admin = admin;
     static_assert(groups::INVITE_SENT == ::INVITE_SENT);
     static_assert(groups::INVITE_FAILED == ::INVITE_FAILED);
+    static_assert(groups::INVITE_NOT_SENT == ::INVITE_NOT_SENT);
     m.invited = invite_status;
     m.promoted = promotion_status;
     m.removed = removed_status;

--- a/src/onionreq/builder.cpp
+++ b/src/onionreq/builder.cpp
@@ -179,10 +179,14 @@ extern "C" {
 using session::ustring;
 
 LIBSESSION_C_API void onion_request_builder_init(onion_request_builder_object** builder) {
-    auto c = std::make_unique<session::onionreq::Builder>();
     auto c_builder = std::make_unique<onion_request_builder_object>();
-    c_builder->internals = c.release();
+    c_builder->internals = new session::onionreq::Builder{};
     *builder = c_builder.release();
+}
+
+LIBSESSION_C_API void onion_request_builder_free(onion_request_builder_object* builder) {
+    delete static_cast<session::onionreq::Builder*>(builder->internals);
+    delete builder;
 }
 
 LIBSESSION_C_API void onion_request_builder_set_enc_type(
@@ -252,7 +256,7 @@ LIBSESSION_C_API bool onion_request_builder_build(
     assert(builder && payload_in);
 
     try {
-        auto unboxed_builder = unbox(builder);
+        auto& unboxed_builder = unbox(builder);
         auto payload = unboxed_builder.build(ustring{payload_in, payload_in_len});
 
         if (unboxed_builder.final_hop_x25519_keypair) {

--- a/tests/test_group_members.cpp
+++ b/tests/test_group_members.cpp
@@ -71,7 +71,7 @@ TEST_CASE("Group Members", "[config][groups][members]") {
     // 10 admins:
     for (int i = 0; i < 10; i++) {
         auto m = gmem1.get_or_construct(sids[i]);
-        m.accept_promotion();
+        m.set_promotion_accepted();
         m.name = "Admin " + std::to_string(i);
         m.profile_picture.url = "http://example.com/" + std::to_string(i);
         m.profile_picture.key =
@@ -122,14 +122,14 @@ TEST_CASE("Group Members", "[config][groups][members]") {
             CHECK_FALSE(m.should_remove_messages());
             CHECK_FALSE(m.supplement);
             if (i < 10) {
-                CHECK_FALSE(m.invite_needs_send());
+                CHECK_FALSE(m.invite_not_sent());
                 CHECK_FALSE(m.invite_pending());
                 CHECK(m.admin);
                 CHECK(m.name == "Admin " + std::to_string(i));
                 CHECK_FALSE(m.profile_picture.empty());
                 CHECK(m.promoted());
             } else {
-                CHECK(m.invite_needs_send());
+                CHECK(m.invite_not_sent());
                 CHECK(m.invite_pending());
                 CHECK_FALSE(m.admin);
                 CHECK_FALSE(m.promoted());
@@ -203,7 +203,7 @@ TEST_CASE("Group Members", "[config][groups][members]") {
                           : ""_hexbytes));
             CHECK(m.profile_picture.url ==
                   (i < 20 ? "http://example.com/" + std::to_string(i) : ""));
-            CHECK(m.invite_needs_send() == (i >= 10 && i < 50));
+            CHECK(m.invite_not_sent() == (i >= 10 && i < 50));
             CHECK(m.invite_pending() == (i >= 10 && i < 58));
             CHECK(m.invite_failed() == (55 <= i && i < 58));
             CHECK(m.supplement == (i % 2 && 50 < i && i < 58));
@@ -229,7 +229,7 @@ TEST_CASE("Group Members", "[config][groups][members]") {
             gmem1.set(m);
         } else if (i == 58) {
             auto m = gmem1.get(sids[i]).value();
-            m.accept_promotion();
+            m.set_promotion_accepted();
             gmem1.set(m);
         } else if (i == 59) {
             auto m = gmem1.get(sids[i]).value();
@@ -257,7 +257,7 @@ TEST_CASE("Group Members", "[config][groups][members]") {
                           : ""_hexbytes));
             CHECK(m.profile_picture.url ==
                   (i < 20 ? "http://example.com/" + std::to_string(i) : ""));
-            CHECK(m.invite_needs_send() == (i >= 10 && i < 50));
+            CHECK(m.invite_not_sent() == (i >= 10 && i < 50));
             CHECK(m.invite_pending() == ((i >= 10 && i < 50) || i == 53 || (i >= 55 && i < 58)));
             CHECK(m.invite_failed() == (i == 57));
             CHECK(m.supplement == (i == 55 || i == 57));


### PR DESCRIPTION
- Added an 'INVITE_NOT_SENT' status which is the default used when creating a new group member
- Added a groups_keys_free function to the C API
- Added a groups_keys_storage_namespace function to the C API
- Updated the promotion functions based on the new status options