### PR TITLE
feat: moved community url max length and qs_pubkey to the cpp header file

### DIFF
--- a/include/session/config/community.hpp
+++ b/include/session/config/community.hpp
@@ -18,6 +18,10 @@ struct community {
     // 267 = len('https://') + 253 (max valid DNS name length) + len(':XXXXX')
     static constexpr size_t BASE_URL_MAX_LENGTH = 267;
     static constexpr size_t ROOM_MAX_LENGTH = 64;
+    static constexpr std::string_view qs_pubkey{"?public_key="};
+    static const size_t FULL_URL_MAX_LENGTH = BASE_URL_MAX_LENGTH + 3 /* '/r/' */ +
+                                              ROOM_MAX_LENGTH + qs_pubkey.size() +
+                                              64 /*pubkey hex*/ + 1 /*null terminator*/;
 
     community() = default;
 

--- a/src/config/community.cpp
+++ b/src/config/community.cpp
@@ -74,8 +74,6 @@ void community::set_room(std::string_view room) {
     localized_room_ = room;
 }
 
-static constexpr std::string_view qs_pubkey{"?public_key="};
-
 std::string community::full_url() const {
     return full_url(base_url(), room(), pubkey());
 }
@@ -230,8 +228,7 @@ LIBSESSION_C_API const size_t COMMUNITY_BASE_URL_MAX_LENGTH =
 LIBSESSION_C_API const size_t COMMUNITY_ROOM_MAX_LENGTH =
         session::config::community::ROOM_MAX_LENGTH;
 LIBSESSION_C_API const size_t COMMUNITY_FULL_URL_MAX_LENGTH =
-        COMMUNITY_BASE_URL_MAX_LENGTH + 3 /* '/r/' */ + COMMUNITY_ROOM_MAX_LENGTH +
-        session::config::qs_pubkey.size() + 64 /*pubkey hex*/ + 1 /*null terminator*/;
+        session::config::community::FULL_URL_MAX_LENGTH;
 
 LIBSESSION_C_API bool community_parse_full_url(
         const char* full_url, char* base_url, char* room_token, unsigned char* pubkey) {


### PR DESCRIPTION
it is now used in libsession_util_nodejs and is exported as a constant