### PR TITLE
Fix dirty() not setting _needs_dump when already dirty

### DIFF
--- a/src/config/base.cpp
+++ b/src/config/base.cpp
@@ -39,6 +39,8 @@ MutableConfigMessage& ConfigBase::dirty() {
     if (_state != ConfigState::Dirty) {
         set_state(ConfigState::Dirty);
         _config = std::make_unique<MutableConfigMessage>(*_config, increment_seqno);
+    } else {
+        _needs_dump = true;
     }
 
     if (auto* mut = dynamic_cast<MutableConfigMessage*>(_config.get()))


### PR DESCRIPTION
If a dirty config gets dumped, _needs_dump gets reset to false, but then if it is updated again, _needs_dump wasn't getting set because the config was already dirty, and thus not entering the code path that reset _needs_dump.