### PR TITLE
feat: allow config wrappers to be extended

### DIFF
--- a/include/session/config/groups/info.hpp
+++ b/include/session/config/groups/info.hpp
@@ -26,7 +26,7 @@ using namespace std::literals;
 /// p - group profile url
 /// q - group profile decryption key (binary)
 
-class Info final : public ConfigBase {
+class Info : public ConfigBase {
 
   public:
     /// Limits for the name & description strings, in bytes.  If longer, we truncate to these

--- a/include/session/config/groups/keys.hpp
+++ b/include/session/config/groups/keys.hpp
@@ -72,7 +72,7 @@ using namespace std::literals;
 /// - A new key and nonce is created from a 56-byte H(M0 || M1 || ... || Mn || g || S,
 ///   key="SessionGroupKeyGen"), where S = H(group_seed, key="SessionGroupKeySeed").
 
-class Keys final : public ConfigSig {
+class Keys : public ConfigSig {
 
     Ed25519Secret user_ed25519_sk;
 

--- a/include/session/config/groups/members.hpp
+++ b/include/session/config/groups/members.hpp
@@ -325,7 +325,7 @@ struct member {
     void load(const dict& info_dict);
 };
 
-class Members final : public ConfigBase {
+class Members : public ConfigBase {
 
   public:
     // No default constructor

--- a/include/session/config/user_profile.hpp
+++ b/include/session/config/user_profile.hpp
@@ -25,7 +25,7 @@ using namespace std::literals;
 ///     omitted if the setting has not been explicitly set (or has been explicitly cleared for some
 ///     reason).
 
-class UserProfile final : public ConfigBase {
+class UserProfile : public ConfigBase {
 
   public:
     // No default constructor

--- a/tests/swarm-auth-test.cpp
+++ b/tests/swarm-auth-test.cpp
@@ -46,15 +46,6 @@ static std::string session_id_from_ed(ustring_view ed_pk) {
     return sid;
 }
 
-// Hacky little class that implements `[n]` on a std::list.  This is inefficient (since it access
-// has to iterate n times through the list) but we only use it on small lists in this test code so
-// convenience wins over efficiency.  (Why not just use a vector?  Because vectors requires `T` to
-// be moveable, so we'd either have to use std::unique_ptr for members, which is also annoying).
-template <typename T>
-struct hacky_list : std::list<T> {
-    T& operator[](size_t n) { return *std::next(std::begin(*this), n); }
-};
-
 struct pseudo_client {
     std::array<unsigned char, 64> secret_key;
     const ustring_view public_key{secret_key.data() + 32, 32};


### PR DESCRIPTION
Extending wrappers makes binding code nicer, as we can batch a few calls to the real wrapper as a single one, and then expose it directly.
For instance, we can extend the existing usergroups wrapper to provide a `all_legacy__groups()` which iterates over all of them and returns them rather than having to deal with the iterator on the binding code.

We could do this on the wrapper code too, but extending them allows to keep the logic contained with the relevant wrapper.